### PR TITLE
By-pass the classification workflow for RESTORE+ map default choice

### DIFF
--- a/notebooks/Module_implementation.ipynb
+++ b/notebooks/Module_implementation.ipynb
@@ -20,10 +20,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "1be9d7e5",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "[notice] A new release of pip is available: 25.3 -> 26.0.1\n",
+      "[notice] To update, run: python.exe -m pip install --upgrade pip\n"
+     ]
+    }
+   ],
    "source": [
     "#This code is used if the notebook is implemented in github codespace. Just remove the (#)\n",
     "!python -m pip install .. --quiet"
@@ -31,10 +41,51 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "d131ed9b",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "    EARTH ENGINE AUTHENTICATION NOTES:\n",
+      "    \n",
+      "    1. Make sure you already have a google cloud project that has enable the Earth Engine API and registered to \n",
+      "       commercial or non-commercial use. For more information visit: https://developers.google.com/earth-engine/guides/access \n",
+      "    \n",
+      "    2. you can authenticate programmatically by calling: from luma_ge.ee_config import authenticate_manually\n",
+      "       authenticate_manually()\n",
+      "    \n",
+      "    3. This will open a web browser. Sign in with your Google account that has Earth Engine access.\n",
+      "    \n",
+      "    4. Copy the authorization code from the browser and paste it in the terminal.\n",
+      "    \n",
+      "    \n",
+      "    For more details, visit: https://developers.google.com/earth-engine/guides/python_install\n",
+      "    \n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Manual authentication failed: Not signed up for Earth Engine or project is not registered. Visit https://developers.google.com/earth-engine/guides/access\n",
+      "Service account initialization failed: Caller does not have required permission to use project ee-epstm2024. Grant the caller the roles/serviceusage.serviceUsageConsumer role, or a custom role with the serviceusage.services.use permission, by visiting https://console.developers.google.com/iam-admin/iam?project=ee-epstm2024 and then retry. Propagation of the new permission may take a few minutes.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Earth Engine initialized with service account successfully!\n",
+      "Initialized: True\n",
+      "Authenticated: True\n",
+      "Project: projects/ee-epstm2024/assets/Reference_data_sumsel_test\n"
+     ]
+    }
+   ],
    "source": [
     "import ee \n",
     "import luma_ge\n",
@@ -81,7 +132,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "4034d1df",
    "metadata": {},
    "outputs": [],
@@ -93,10 +144,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "90fd7cd6",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# #Initialize shapefile validator\n",
     "# print(\"=\" * 60)\n",
@@ -125,10 +211,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "3afe3a78",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# Initialize KML validator\n",
     "# print(\"\\n\" + \"=\" * 60)\n",
@@ -167,10 +288,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "47d19c21",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "import geemap\n",
     "from luma_ge.data_acquisition import Reflectance_Data, Reflectance_Stats, final_Image\n",
@@ -179,10 +335,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "d8507432",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "#Set the country and province for the AOI using GAUL admin boundaries\n",
     "#aoi = get_aoi_from_gaul(country=\"Indonesia\", province=\"Sumatera Selatan\")\n",
@@ -191,10 +382,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "b9e11db3",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "#alternatively, you can also select smaller AOI using regency data below\n",
     "import pandas as pd\n",
@@ -226,10 +452,68 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "3027fb75",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-03-23 14:57:59,980 - Reflectance_Data - INFO - ReflectanceData initialized.\n",
+      "2026-03-23 14:57:59,981 - final_Image - INFO - final_Image creation initialized.\n",
+      "2026-03-23 14:57:59,982 - Reflectance_Data - INFO - Starting data fetch for Landsat 8 Operational Land Imager Surface Reflectance\n",
+      "2026-03-23 14:57:59,983 - Reflectance_Data - INFO - Date range: 2017-01-01 to 2017-12-31\n",
+      "2026-03-23 14:57:59,984 - Reflectance_Data - INFO - Cloud cover threshold: 40%\n",
+      "2026-03-23 14:57:59,984 - Reflectance_Data - INFO - detailed statistics will not be computed\n",
+      "2026-03-23 14:57:59,986 - Reflectance_Stats - INFO - Reflectance Stats initialized.\n",
+      "2026-03-23 14:57:59,987 - Reflectance_Data - INFO - Filtered collection created (use compute_detailed_stats=True for more information)\n",
+      "2026-03-23 14:58:01,193 - final_Image - INFO - Creating quality mosaic from 5 images using NDVI as quality metric\n",
+      "2026-03-23 14:58:01,196 - final_Image - INFO - Quality mosaic created covering AOI with best available pixels\n",
+      "2026-03-23 14:58:03,724 - final_Image - INFO - Mosaic date range: 2017-05-05 to 2017-08-09\n",
+      "2026-03-23 14:58:04,228 - final_Image - INFO - Creating Median composite from 5 images\n",
+      "2026-03-23 14:58:04,230 - final_Image - INFO - Composite clipped to AOI\n",
+      "2026-03-23 14:58:05,152 - final_Image - INFO - Composite created from 2017-05-05 to 2017-08-09\n",
+      "2026-03-23 14:58:05,154 - final_Image - INFO - Calculating data coverage within AOI...\n",
+      "2026-03-23 14:58:10,537 - final_Image - INFO - Data coverage: 92.4% (578.22 km² of 625.90 km²)\n",
+      "2026-03-23 14:58:10,538 - final_Image - INFO - Data gaps: 7.6% (47.68 km²)\n"
+     ]
+    }
+   ],
    "source": [
     "#========== FIRST RETRIVE THE MULTISPECTRAL BAND===========\n",
     "#Intialize the relfectance class data function\n",
@@ -260,10 +544,75 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "62243459",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-03-23 14:58:15,611 - Reflectance_Stats - INFO - Reflectance Stats initialized.\n",
+      "2026-03-23 14:58:15,611 - Reflectance_Data - INFO - Starting thermal data fetch for Landsat 8 Top-of-atmosphere reflectance\n",
+      "2026-03-23 14:58:15,613 - Reflectance_Data - INFO - Date range: 2017-01-01 to 2017-12-31\n",
+      "2026-03-23 14:58:15,615 - Reflectance_Data - INFO - Cloud cover threshold: 40%\n",
+      "2026-03-23 14:58:15,616 - Reflectance_Data - INFO - Fast mode enabled - detailed statistics will not be computed\n",
+      "2026-03-23 14:58:15,617 - Reflectance_Data - INFO - Filtered collection created (use compute_detailed_stats=True for detailed info)\n",
+      "2026-03-23 14:58:16,132 - final_Image - INFO - Creating Median composite from 5 images\n",
+      "2026-03-23 14:58:16,133 - final_Image - INFO - Composite clipped to AOI\n",
+      "2026-03-23 14:58:17,123 - final_Image - INFO - Composite created from 2017-05-05 to 2017-08-09\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ad7b11162e3245f48c95f9c92180ed0f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map(center=[-4.117597821329865, 103.26638606871309], controls=(WidgetControl(options=['position', 'transparent…"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "#retive thermal bands from TOA\n",
     "thermal_bands, thermal_stats = optical_reflectance.get_thermal_bands(aoi, start, end, cloud_cover=40, compute_detailed_stats=False)\n",
@@ -286,10 +635,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "5dcdcd22",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# #intialize the statistic class\n",
     "# stats = Reflectance_Stats()\n",
@@ -307,10 +691,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "49d212e5",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# export_task = ee.batch.Export.image.toDrive(\n",
     "#     image=stacked_landsat,\n",
@@ -353,10 +772,54 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "id": "2240e73f",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Land Cover Classification Scheme Manager initialized!\n",
+      "Current class count: 0\n",
+      "No classes defined yet.\n"
+     ]
+    }
+   ],
    "source": [
     "from luma_ge.classification_scheme import LULC_Scheme_Manager\n",
     "#Initialize the LULC Scheme Manager\n",
@@ -391,10 +854,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "id": "2c972c28",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# import pandas as pd\n",
     "# #Reset manager for CSV upload example\n",
@@ -419,10 +917,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "id": "dccbff10",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# # Process CSV upload\n",
     "# success, message = manager.process_csv_upload(df, id_col, name_col, color_col)\n",
@@ -452,10 +985,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "id": "458a8020",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# #Reset manager for manual input example\n",
     "# manager = LULC_Scheme_Manager()\n",
@@ -483,10 +1051,53 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "id": "213558d3",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Editing a Class ===\n",
+      "No classes defined yet.\n"
+     ]
+    }
+   ],
    "source": [
     "# Example: Edit an existing class\n",
     "print(\"=== Editing a Class ===\")\n",
@@ -517,10 +1128,71 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "id": "11b2702d",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Available Default Schemes ===\n",
+      "\n",
+      "RESTORE+ Project: 17 classes\n",
+      "  - ID 1: Undisturbed dry-land forest (#006400)\n",
+      "  - ID 2: Logged-over dry-land forest (#228B22)\n",
+      "  - ID 3: Undisturbed mangrove (#4169E1)\n",
+      "  - ID 4: Logged-over mangrove (#87CEEB)\n",
+      "  - ID 5: Undisturbed swamp forest (#2E8B57)\n",
+      "  - ID 6: Logged-over swamp forest (#8FBC8F)\n",
+      "  - ID 7: Agroforestry (#9ACD32)\n",
+      "  - ID 8: Plantation forest (#32CD32)\n",
+      "  - ID 9: Rubber monoculture (#8B4513)\n",
+      "  - ID 10: Oil palm monoculture (#FF8C00)\n",
+      "  - ID 11: Other monoculture (#DAA520)\n",
+      "  - ID 12: Grass/savanna (#ADFF2F)\n",
+      "  - ID 13: Shrub (#90EE90)\n",
+      "  - ID 14: Cropland (#FFFF00)\n",
+      "  - ID 15: Settlement (#FF0000)\n",
+      "  - ID 16: Cleared land (#D2B48C)\n",
+      "  - ID 17: Waterbody (#0000FF)\n"
+     ]
+    }
+   ],
    "source": [
     "# Reset manager for default scheme example\n",
     "manager = LULC_Scheme_Manager()\n",
@@ -536,10 +1208,230 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "id": "982940ad",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Loaded RESTORE+ Project with 17 classes\n",
+      "\n",
+      "=== Current Classification Scheme ===\n",
+      " ID            Land Cover Class Color Palette\n",
+      "  1 Undisturbed dry-land forest       #006400\n",
+      "  2 Logged-over dry-land forest       #228B22\n",
+      "  3        Undisturbed mangrove       #4169E1\n",
+      "  4        Logged-over mangrove       #87CEEB\n",
+      "  5    Undisturbed swamp forest       #2E8B57\n",
+      "  6    Logged-over swamp forest       #8FBC8F\n",
+      "  7                Agroforestry       #9ACD32\n",
+      "  8           Plantation forest       #32CD32\n",
+      "  9          Rubber monoculture       #8B4513\n",
+      " 10        Oil palm monoculture       #FF8C00\n",
+      " 11           Other monoculture       #DAA520\n",
+      " 12               Grass/savanna       #ADFF2F\n",
+      " 13                       Shrub       #90EE90\n",
+      " 14                    Cropland       #FFFF00\n",
+      " 15                  Settlement       #FF0000\n",
+      " 16                Cleared land       #D2B48C\n",
+      " 17                   Waterbody       #0000FF\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>ID</th>\n",
+       "      <th>Land Cover Class</th>\n",
+       "      <th>Color Palette</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "      <td>Undisturbed dry-land forest</td>\n",
+       "      <td>#006400</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2</td>\n",
+       "      <td>Logged-over dry-land forest</td>\n",
+       "      <td>#228B22</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>3</td>\n",
+       "      <td>Undisturbed mangrove</td>\n",
+       "      <td>#4169E1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>4</td>\n",
+       "      <td>Logged-over mangrove</td>\n",
+       "      <td>#87CEEB</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>5</td>\n",
+       "      <td>Undisturbed swamp forest</td>\n",
+       "      <td>#2E8B57</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>6</td>\n",
+       "      <td>Logged-over swamp forest</td>\n",
+       "      <td>#8FBC8F</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>7</td>\n",
+       "      <td>Agroforestry</td>\n",
+       "      <td>#9ACD32</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>8</td>\n",
+       "      <td>Plantation forest</td>\n",
+       "      <td>#32CD32</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>9</td>\n",
+       "      <td>Rubber monoculture</td>\n",
+       "      <td>#8B4513</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>10</td>\n",
+       "      <td>Oil palm monoculture</td>\n",
+       "      <td>#FF8C00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>11</td>\n",
+       "      <td>Other monoculture</td>\n",
+       "      <td>#DAA520</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
+       "      <td>12</td>\n",
+       "      <td>Grass/savanna</td>\n",
+       "      <td>#ADFF2F</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12</th>\n",
+       "      <td>13</td>\n",
+       "      <td>Shrub</td>\n",
+       "      <td>#90EE90</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13</th>\n",
+       "      <td>14</td>\n",
+       "      <td>Cropland</td>\n",
+       "      <td>#FFFF00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>14</th>\n",
+       "      <td>15</td>\n",
+       "      <td>Settlement</td>\n",
+       "      <td>#FF0000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>15</th>\n",
+       "      <td>16</td>\n",
+       "      <td>Cleared land</td>\n",
+       "      <td>#D2B48C</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>16</th>\n",
+       "      <td>17</td>\n",
+       "      <td>Waterbody</td>\n",
+       "      <td>#0000FF</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    ID             Land Cover Class Color Palette\n",
+       "0    1  Undisturbed dry-land forest       #006400\n",
+       "1    2  Logged-over dry-land forest       #228B22\n",
+       "2    3         Undisturbed mangrove       #4169E1\n",
+       "3    4         Logged-over mangrove       #87CEEB\n",
+       "4    5     Undisturbed swamp forest       #2E8B57\n",
+       "5    6     Logged-over swamp forest       #8FBC8F\n",
+       "6    7                 Agroforestry       #9ACD32\n",
+       "7    8            Plantation forest       #32CD32\n",
+       "8    9           Rubber monoculture       #8B4513\n",
+       "9   10         Oil palm monoculture       #FF8C00\n",
+       "10  11            Other monoculture       #DAA520\n",
+       "11  12                Grass/savanna       #ADFF2F\n",
+       "12  13                        Shrub       #90EE90\n",
+       "13  14                     Cropland       #FFFF00\n",
+       "14  15                   Settlement       #FF0000\n",
+       "15  16                 Cleared land       #D2B48C\n",
+       "16  17                    Waterbody       #0000FF"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Load the RESTORE+ default scheme\n",
     "scheme_name = \"RESTORE+ Project\"\n",
@@ -564,10 +1456,52 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "id": "8cce5575",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'scheme_name': 'RESTORE+ Project', 'classes_of_interest': [1]}\n"
+     ]
+    }
+   ],
    "source": [
     "manager = LULC_Scheme_Manager()\n",
     "manager.load_default_scheme(\"RESTORE+ Project\")\n",
@@ -591,10 +1525,73 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "id": "fecc7b3e",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Export Classification Scheme ===\n",
+      "Classification DataFrame:\n",
+      "    ID             Land Cover Class Color Palette\n",
+      "0    1  Undisturbed dry-land forest       #006400\n",
+      "1    2  Logged-over dry-land forest       #228B22\n",
+      "2    3         Undisturbed mangrove       #4169E1\n",
+      "3    4         Logged-over mangrove       #87CEEB\n",
+      "4    5     Undisturbed swamp forest       #2E8B57\n",
+      "5    6     Logged-over swamp forest       #8FBC8F\n",
+      "6    7                 Agroforestry       #9ACD32\n",
+      "7    8            Plantation forest       #32CD32\n",
+      "8    9           Rubber monoculture       #8B4513\n",
+      "9   10         Oil palm monoculture       #FF8C00\n",
+      "10  11            Other monoculture       #DAA520\n",
+      "11  12                Grass/savanna       #ADFF2F\n",
+      "12  13                        Shrub       #90EE90\n",
+      "13  14                     Cropland       #FFFF00\n",
+      "14  15                   Settlement       #FF0000\n",
+      "15  16                 Cleared land       #D2B48C\n",
+      "16  17                    Waterbody       #0000FF\n",
+      "\n",
+      "✅ Classification scheme saved to: ../Selected_LC_Classification_Scheme.csv\n"
+     ]
+    }
+   ],
    "source": [
     "print(\"=== Export Classification Scheme ===\")\n",
     "#Convert the selected  classification scheme manager to dataframe\n",
@@ -637,10 +1634,57 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "id": "d956b21d",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Checking Prerequisites ===\n",
+      "✅ AOI from Module 1 is available\n",
+      "✅ Classification scheme from Module 2 is available\n",
+      "   - Number of classes: 17\n",
+      "\n",
+      "✅ All prerequisites met! You can proceed with training data collection.\n"
+     ]
+    }
+   ],
    "source": [
     "print(\"=== Checking Prerequisites ===\")\n",
     "#Load from previous module\n",
@@ -673,10 +1717,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "id": "ae398a78",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# Modul 3a \n",
     "# Import modules and functions\n",
@@ -695,10 +1774,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "id": "7411b55c",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# # ----- Data Input -----\n",
     "# # 1. Decision to upload data\n",
@@ -718,10 +1832,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "id": "f745ae9d",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# # ----- System response 3.2.a -----\n",
     "# # Set class field\n",
@@ -777,10 +1926,211 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "id": "4869adce",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-03-23 14:58:20,767 - luma_ge.sample_data - INFO - Loading training data from EE asset: projects/ee-rg2icraf/assets/Indonesia_lulc_Sample\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " Loading default reference training data...\n",
+      "Column 'Land Cover Class' renamed to 'LULC_Type'\n",
+      "Loading reference training data from Earth Engine...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-03-23 14:58:24,089 - luma_ge.sample_data - INFO - Initial feature count: 1130000\n",
+      "2026-03-23 14:58:24,091 - luma_ge.sample_data - INFO - Filtering by AOI bounds...\n",
+      "2026-03-23 14:58:24,092 - luma_ge.sample_data - INFO - AOI geometry type: <class 'ee.geometry.Geometry'>\n",
+      "2026-03-23 14:58:25,516 - luma_ge.sample_data - INFO - Features after AOI filter: 99\n",
+      "2026-03-23 14:58:25,517 - luma_ge.sample_data - INFO - Converting to GeoDataFrame...\n",
+      "2026-03-23 14:58:27,283 - luma_ge.sample_data - INFO - Collection size: 99\n",
+      "2026-03-23 14:58:27,284 - luma_ge.sample_data - INFO - Collection size (99) is within normal limits, loading directly\n",
+      "2026-03-23 14:58:29,202 - luma_ge.sample_data - INFO - Features to convert: 99\n",
+      "2026-03-23 14:58:29,209 - luma_ge.sample_data - INFO - Successfully processed 99 features\n",
+      "2026-03-23 14:58:29,221 - luma_ge.sample_data - INFO - Unique classes in training data: [ 1  2  7  9 13 14 15]\n",
+      "2026-03-23 14:58:29,227 - luma_ge.sample_data - INFO - Class counts: {7: 42, 1: 26, 14: 11, 2: 10, 13: 4, 9: 3, 15: 3}\n",
+      "2026-03-23 14:58:29,228 - luma_ge.sample_data - INFO - Validating classes with use_class_ids=True\n",
+      "2026-03-23 14:58:29,230 - luma_ge.sample_data - INFO - Class field: kelas\n",
+      "2026-03-23 14:58:29,231 - luma_ge.sample_data - INFO - Training data type: <class 'geopandas.geodataframe.GeoDataFrame'>\n",
+      "2026-03-23 14:58:29,232 - luma_ge.sample_data - INFO - Landcover DF columns: ['ID', 'LULC_Type', 'Color Palette']\n",
+      "2026-03-23 14:58:29,233 - luma_ge.sample_data - INFO - Valid IDs in landcover_df: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]\n",
+      "2026-03-23 14:58:29,234 - luma_ge.sample_data - INFO - Processing GeoDataFrame with 99 features\n",
+      "2026-03-23 14:58:29,236 - luma_ge.sample_data - INFO - Unique classes in training data: [ 1  2  7  9 13 14 15]\n",
+      "2026-03-23 14:58:29,238 - luma_ge.sample_data - INFO - Valid class ID: 1\n",
+      "2026-03-23 14:58:29,240 - luma_ge.sample_data - INFO - Valid class ID: 2\n",
+      "2026-03-23 14:58:29,241 - luma_ge.sample_data - INFO - Valid class ID: 7\n",
+      "2026-03-23 14:58:29,243 - luma_ge.sample_data - INFO - Valid class ID: 9\n",
+      "2026-03-23 14:58:29,244 - luma_ge.sample_data - INFO - Valid class ID: 13\n",
+      "2026-03-23 14:58:29,245 - luma_ge.sample_data - INFO - Valid class ID: 14\n",
+      "2026-03-23 14:58:29,246 - luma_ge.sample_data - INFO - Valid class ID: 15\n",
+      "2026-03-23 14:58:29,247 - luma_ge.sample_data - INFO - Valid classes: [np.int64(1), np.int64(2), np.int64(7), np.int64(9), np.int64(13), np.int64(14), np.int64(15)]\n",
+      "2026-03-23 14:58:29,248 - luma_ge.sample_data - INFO - Invalid classes: []\n",
+      "2026-03-23 14:58:29,252 - luma_ge.sample_data - INFO - Features after class validation: 99\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Processing and validating reference data...\n",
+      "✅ Reference training data loaded and processed successfully!\n",
+      "Total samples: 99\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>ID</th>\n",
+       "      <th>LULC_class</th>\n",
+       "      <th>Sample_Count</th>\n",
+       "      <th>Percentage</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>7</td>\n",
+       "      <td>Agroforestry</td>\n",
+       "      <td>42</td>\n",
+       "      <td>42.424242</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1</td>\n",
+       "      <td>Undisturbed dry-land forest</td>\n",
+       "      <td>26</td>\n",
+       "      <td>26.262626</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>14</td>\n",
+       "      <td>Cropland</td>\n",
+       "      <td>11</td>\n",
+       "      <td>11.111111</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2</td>\n",
+       "      <td>Logged-over dry-land forest</td>\n",
+       "      <td>10</td>\n",
+       "      <td>10.101010</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>13</td>\n",
+       "      <td>Shrub</td>\n",
+       "      <td>4</td>\n",
+       "      <td>4.040404</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>9</td>\n",
+       "      <td>Rubber monoculture</td>\n",
+       "      <td>3</td>\n",
+       "      <td>3.030303</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>15</td>\n",
+       "      <td>Settlement</td>\n",
+       "      <td>3</td>\n",
+       "      <td>3.030303</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   ID                   LULC_class  Sample_Count  Percentage\n",
+       "0   7                 Agroforestry            42   42.424242\n",
+       "1   1  Undisturbed dry-land forest            26   26.262626\n",
+       "2  14                     Cropland            11   11.111111\n",
+       "3   2  Logged-over dry-land forest            10   10.101010\n",
+       "4  13                        Shrub             4    4.040404\n",
+       "5   9           Rubber monoculture             3    3.030303\n",
+       "6  15                   Settlement             3    3.030303"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Validation Results:\n",
+      "- Total points loaded: 99\n",
+      "- Points after class filter: 99\n",
+      "- Valid points (within AOI): 99\n",
+      "- Invalid classes: 0\n"
+     ]
+    }
+   ],
    "source": [
     "print(\" Loading default reference training data...\")\n",
     "TrainEePath = 'projects/ee-rg2icraf/assets/Indonesia_lulc_Sample'\n",
@@ -863,10 +2213,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "id": "e1785681",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "#Import the sample quality functions\n",
     "from luma_ge.sample_data_quality import sample_quality, spectral_plotter\n",
@@ -884,10 +2269,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 28,
    "id": "7fcd6b98",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# roi_path = '../data/Training_Sumsel_Data.shp'\n",
     "# labeled_roi = geemap.shp_to_ee('../data/Training_Sumsel_Data.shp')\n",
@@ -910,10 +2330,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 29,
    "id": "6f87c8bb",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# #Sample statistic (pixel value extracted from the imagery)\n",
     "# pixel_stats = analyzer.sample_pixel_stats(pixel_extract)\n",
@@ -923,10 +2378,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 30,
    "id": "fb8effda",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# #Perform separability Analysis (iether using Transformed Divergence or Jeffries Matutista )\n",
     "# separability_analysis = analyzer.get_separability_df(pixel_extract, method='TD')\n",
@@ -935,10 +2425,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 31,
    "id": "e4dad481",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# #Get the lowest separability\n",
     "# lowest_sep = analyzer.lowest_separability(pixel_extract)\n",
@@ -947,10 +2472,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 32,
    "id": "3347eecf",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# # Overall separability summary\n",
     "# sep_summary = analyzer.sum_separability(pixel_extract)\n",
@@ -968,10 +2528,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 33,
    "id": "36d23c90",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# #Box plot to detect outlier\n",
     "# ploter = spectral_plotter(analyzer)\n",
@@ -982,10 +2577,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 34,
    "id": "f5d4625e",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# #static scatter plot\n",
     "# stat_plot = ploter.static_scatter_plot(pixel_extract, x_band='NIR', y_band='RED', add_ellipse=True)"
@@ -993,10 +2623,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 35,
    "id": "d21da65f",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# #3D scatter plot\n",
     "# multi_d_scater = ploter.scatter_plot_3d(pixel_extract)\n",
@@ -1021,10 +2686,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 36,
    "id": "bac11b30",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "from luma_ge.classification import FeatureExtraction, Generate_LULC\n",
     "import numpy as np\n",
@@ -1042,10 +2742,60 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 37,
    "id": "6253ee61",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-03-23 14:58:37,952 - pyogrio._io - INFO - Created 99 records\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Stratified Random Split Training Pixel Size: 51\n",
+      "Stratified Random Split Testing Pixel Size: 48\n"
+     ]
+    }
+   ],
    "source": [
     "labeled_roi = geemap.gdf_to_ee(TrainDataFinal)\n",
     "\n",
@@ -1057,10 +2807,54 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 38,
    "id": "943ac0d8",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Performing Classification...\n",
+      "Evaluating model performance...\n",
+      "✓ Model evaluation completed\n"
+     ]
+    }
+   ],
    "source": [
     "classifier = Generate_LULC()\n",
     "print(\"Performing Classification...\")\n",
@@ -1085,10 +2879,52 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 39,
    "id": "47e81ae5",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'classification': {'1': 85827.52941176463, '2': 73377.44313725489, '7': 490033.92549019546}}\n"
+     ]
+    }
+   ],
    "source": [
     "orig_hist = classification_map.reduceRegion(\n",
     "    reducer=ee.Reducer.frequencyHistogram(),\n",
@@ -1110,10 +2946,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 40,
    "id": "592b48ea",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# # Display accuracy results\n",
     "# print(\"=== Model Performance Summary ===\")\n",
@@ -1138,10 +3009,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 41,
    "id": "a32e88e6",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# # Visualize confusion matrix\n",
     "# confusion_matrix = np.array(accuracy_metrics['confusion_matrix'])\n",
@@ -1159,10 +3065,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 42,
    "id": "4f7077f3",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# # Get feature importance\n",
     "# print(\"Analyzing feature importance...\")\n",
@@ -1205,10 +3146,60 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 43,
    "id": "536ab3fe",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7fa23b3e0f3243bab4f83dc44cfa730e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map(center=[-4.117597821329865, 103.26638606871309], controls=(WidgetControl(options=['position', 'transparent…"
+      ]
+     },
+     "execution_count": 43,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# === Load Classification Scheme ===\n",
     "scheme = pd.read_csv(\"../Selected_LC_Classification_Scheme.csv\", sep=None, engine=\"python\")\n",
@@ -1249,10 +3240,58 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 44,
    "id": "d20f2e1f",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'histogram': {'1': 85827.52941176463, '999': 563411.3686274507},\n",
+       " 'existing_classes': [1],\n",
+       " 'missing_classes': [],\n",
+       " 'all_classes_present': True}"
+      ]
+     },
+     "execution_count": 44,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Reclassify the map\n",
     "\n",
@@ -1267,10 +3306,60 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 45,
    "id": "b37f21e1",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7fa23b3e0f3243bab4f83dc44cfa730e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map(center=[-4.117597821329865, 103.26638606871309], controls=(WidgetControl(options=['position', 'transparent…"
+      ]
+     },
+     "execution_count": 45,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Prepare Reclassified Visualization\n",
     "\n",
@@ -1322,6 +3411,118 @@
   },
   {
    "cell_type": "markdown",
+   "id": "e00afb23",
+   "metadata": {},
+   "source": [
+    "## Use prebuild map and bypass classiciation workflow"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "id": "58088b84",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[Bypass] Loading prebuilt map for 'RESTORE+ Project' year 2018...\n",
+      "Loaded year    : 2018\n",
+      "Classes in AOI : ['Undisturbed dry-land forest', 'Logged-over dry-land forest', 'Agroforestry', 'Plantation forest', 'Rubber monoculture', 'Oil palm monoculture', 'Grass/savanna', 'Shrub', 'Cropland', 'Settlement', 'Cleared land']\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "073629f9721c4a05a11016e996eb7a21",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map(center=[-4.117597821329865, 103.26638606871309], controls=(WidgetControl(options=['position', 'transparent…"
+      ]
+     },
+     "execution_count": 46,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "generator = Generate_LULC()\n",
+    "\n",
+    "# Check: was a default scheme chosen AND does a prebuilt map exist for it?\n",
+    "KNOWN_DEFAULT_SCHEMES = set(generator._prebuilt_registry.keys())\n",
+    "chosen_scheme = \"RESTORE+ Project\"   # whatever manager exposes\n",
+    "\n",
+    "if chosen_scheme in KNOWN_DEFAULT_SCHEMES:\n",
+    "    # Modules 3–5 skipped entirely\n",
+    "    print(f\"[Bypass] Loading prebuilt map for '{chosen_scheme}' year {2018}...\") # Year can be dynamic based on user input in Module 1\n",
+    "\n",
+    "    result = generator.classify_from_prebuilt(\n",
+    "        scheme_name    = chosen_scheme,\n",
+    "        aoi            = aoi,\n",
+    "        year           = 2018, # make this dynamic based on user input in Module 1\n",
+    "        scheme_classes = manager.classes,\n",
+    "    )\n",
+    "\n",
+    "    final_map       = result[\"final_map\"]\n",
+    "    present_classes = result[\"present_classes\"]\n",
+    "    vis_params      = result[\"vis_params\"]\n",
+    "\n",
+    "    print(f\"Loaded year    : {result['year_used']}\")\n",
+    "    print(f\"Classes in AOI : {[c['Class Name'] for c in present_classes]}\") # safeguard check\n",
+    "\n",
+    "else:\n",
+    "    # ── Normal RF path (Modules 3–6) ──────────────────────────────────────\n",
+    "    # Skip this block if a default scheme with a prebuilt map is selected\n",
+    "    raise NotImplementedError(\n",
+    "        \"Custom scheme RF pipeline not yet wired up in this cell. \"\n",
+    "        \"Select a default scheme to use the prebuilt map bypass.\"\n",
+    "    )\n",
+    "\n",
+    "Map = geemap.Map()\n",
+    "Map.centerObject(aoi, zoom=10)\n",
+    "Map.addLayer(final_map, vis_params, chosen_scheme)\n",
+    "Map"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "8a8c0377",
    "metadata": {},
    "source": [
@@ -1338,10 +3539,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 47,
    "id": "9232a519",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# from luma_ge.accuracy import Thematic_Accuracy_Assessment\n",
     "# #Initialize the accuracy assessment class\n",
@@ -1352,10 +3588,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 48,
    "id": "6f505ccf",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# validation_data = geemap.shp_to_ee(\"../data/Evaluation_Sumsel_data.shp\") \n",
     "\n",

--- a/notebooks/Module_implementation.ipynb
+++ b/notebooks/Module_implementation.ipynb
@@ -20,20 +20,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "1be9d7e5",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "[notice] A new release of pip is available: 25.3 -> 26.0.1\n",
-      "[notice] To update, run: python.exe -m pip install --upgrade pip\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "#This code is used if the notebook is implemented in github codespace. Just remove the (#)\n",
     "!python -m pip install .. --quiet"
@@ -41,51 +31,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "d131ed9b",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "    EARTH ENGINE AUTHENTICATION NOTES:\n",
-      "    \n",
-      "    1. Make sure you already have a google cloud project that has enable the Earth Engine API and registered to \n",
-      "       commercial or non-commercial use. For more information visit: https://developers.google.com/earth-engine/guides/access \n",
-      "    \n",
-      "    2. you can authenticate programmatically by calling: from luma_ge.ee_config import authenticate_manually\n",
-      "       authenticate_manually()\n",
-      "    \n",
-      "    3. This will open a web browser. Sign in with your Google account that has Earth Engine access.\n",
-      "    \n",
-      "    4. Copy the authorization code from the browser and paste it in the terminal.\n",
-      "    \n",
-      "    \n",
-      "    For more details, visit: https://developers.google.com/earth-engine/guides/python_install\n",
-      "    \n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Manual authentication failed: Not signed up for Earth Engine or project is not registered. Visit https://developers.google.com/earth-engine/guides/access\n",
-      "Service account initialization failed: Caller does not have required permission to use project ee-epstm2024. Grant the caller the roles/serviceusage.serviceUsageConsumer role, or a custom role with the serviceusage.services.use permission, by visiting https://console.developers.google.com/iam-admin/iam?project=ee-epstm2024 and then retry. Propagation of the new permission may take a few minutes.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Earth Engine initialized with service account successfully!\n",
-      "Initialized: True\n",
-      "Authenticated: True\n",
-      "Project: projects/ee-epstm2024/assets/Reference_data_sumsel_test\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import ee \n",
     "import luma_ge\n",
@@ -132,7 +81,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "4034d1df",
    "metadata": {},
    "outputs": [],
@@ -144,45 +93,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "90fd7cd6",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <style>\n",
-       "                .geemap-dark {\n",
-       "                    --jp-widgets-color: white;\n",
-       "                    --jp-widgets-label-color: white;\n",
-       "                    --jp-ui-font-color1: white;\n",
-       "                    --jp-layout-color2: #454545;\n",
-       "                    background-color: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-dark .jupyter-button {\n",
-       "                    --jp-layout-color3: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab {\n",
-       "                    background-color: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab .jupyter-button {\n",
-       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "            </style>\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# #Initialize shapefile validator\n",
     "# print(\"=\" * 60)\n",
@@ -211,45 +125,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "3afe3a78",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <style>\n",
-       "                .geemap-dark {\n",
-       "                    --jp-widgets-color: white;\n",
-       "                    --jp-widgets-label-color: white;\n",
-       "                    --jp-ui-font-color1: white;\n",
-       "                    --jp-layout-color2: #454545;\n",
-       "                    background-color: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-dark .jupyter-button {\n",
-       "                    --jp-layout-color3: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab {\n",
-       "                    background-color: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab .jupyter-button {\n",
-       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "            </style>\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Initialize KML validator\n",
     "# print(\"\\n\" + \"=\" * 60)\n",
@@ -288,45 +167,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "47d19c21",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <style>\n",
-       "                .geemap-dark {\n",
-       "                    --jp-widgets-color: white;\n",
-       "                    --jp-widgets-label-color: white;\n",
-       "                    --jp-ui-font-color1: white;\n",
-       "                    --jp-layout-color2: #454545;\n",
-       "                    background-color: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-dark .jupyter-button {\n",
-       "                    --jp-layout-color3: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab {\n",
-       "                    background-color: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab .jupyter-button {\n",
-       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "            </style>\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "import geemap\n",
     "from luma_ge.data_acquisition import Reflectance_Data, Reflectance_Stats, final_Image\n",
@@ -335,45 +179,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "d8507432",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <style>\n",
-       "                .geemap-dark {\n",
-       "                    --jp-widgets-color: white;\n",
-       "                    --jp-widgets-label-color: white;\n",
-       "                    --jp-ui-font-color1: white;\n",
-       "                    --jp-layout-color2: #454545;\n",
-       "                    background-color: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-dark .jupyter-button {\n",
-       "                    --jp-layout-color3: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab {\n",
-       "                    background-color: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab .jupyter-button {\n",
-       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "            </style>\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "#Set the country and province for the AOI using GAUL admin boundaries\n",
     "#aoi = get_aoi_from_gaul(country=\"Indonesia\", province=\"Sumatera Selatan\")\n",
@@ -382,45 +191,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "b9e11db3",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <style>\n",
-       "                .geemap-dark {\n",
-       "                    --jp-widgets-color: white;\n",
-       "                    --jp-widgets-label-color: white;\n",
-       "                    --jp-ui-font-color1: white;\n",
-       "                    --jp-layout-color2: #454545;\n",
-       "                    background-color: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-dark .jupyter-button {\n",
-       "                    --jp-layout-color3: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab {\n",
-       "                    background-color: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab .jupyter-button {\n",
-       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "            </style>\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "#alternatively, you can also select smaller AOI using regency data below\n",
     "import pandas as pd\n",
@@ -452,68 +226,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "3027fb75",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <style>\n",
-       "                .geemap-dark {\n",
-       "                    --jp-widgets-color: white;\n",
-       "                    --jp-widgets-label-color: white;\n",
-       "                    --jp-ui-font-color1: white;\n",
-       "                    --jp-layout-color2: #454545;\n",
-       "                    background-color: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-dark .jupyter-button {\n",
-       "                    --jp-layout-color3: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab {\n",
-       "                    background-color: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab .jupyter-button {\n",
-       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "            </style>\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-03-27 09:07:23,725 - Reflectance_Data - INFO - ReflectanceData initialized.\n",
-      "2026-03-27 09:07:23,726 - final_Image - INFO - final_Image creation initialized.\n",
-      "2026-03-27 09:07:23,728 - Reflectance_Data - INFO - Starting data fetch for Landsat 8 Operational Land Imager Surface Reflectance\n",
-      "2026-03-27 09:07:23,728 - Reflectance_Data - INFO - Date range: 2017-01-01 to 2017-12-31\n",
-      "2026-03-27 09:07:23,729 - Reflectance_Data - INFO - Cloud cover threshold: 40%\n",
-      "2026-03-27 09:07:23,729 - Reflectance_Data - INFO - detailed statistics will not be computed\n",
-      "2026-03-27 09:07:23,730 - Reflectance_Stats - INFO - Reflectance Stats initialized.\n",
-      "2026-03-27 09:07:23,730 - Reflectance_Data - INFO - Filtered collection created (use compute_detailed_stats=True for more information)\n",
-      "2026-03-27 09:07:24,233 - final_Image - INFO - Creating quality mosaic from 5 images using NDVI as quality metric\n",
-      "2026-03-27 09:07:24,236 - final_Image - INFO - Quality mosaic created covering AOI with best available pixels\n",
-      "2026-03-27 09:07:25,208 - final_Image - INFO - Mosaic date range: 2017-05-05 to 2017-08-09\n",
-      "2026-03-27 09:07:26,246 - final_Image - INFO - Creating Median composite from 5 images\n",
-      "2026-03-27 09:07:26,247 - final_Image - INFO - Composite clipped to AOI\n",
-      "2026-03-27 09:07:27,137 - final_Image - INFO - Composite created from 2017-05-05 to 2017-08-09\n",
-      "2026-03-27 09:07:27,139 - final_Image - INFO - Calculating data coverage within AOI...\n",
-      "2026-03-27 09:07:30,690 - final_Image - INFO - Data coverage: 92.4% (578.22 km² of 625.90 km²)\n",
-      "2026-03-27 09:07:30,692 - final_Image - INFO - Data gaps: 7.6% (47.68 km²)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "#========== FIRST RETRIVE THE MULTISPECTRAL BAND===========\n",
     "#Intialize the relfectance class data function\n",
@@ -544,75 +260,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "62243459",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <style>\n",
-       "                .geemap-dark {\n",
-       "                    --jp-widgets-color: white;\n",
-       "                    --jp-widgets-label-color: white;\n",
-       "                    --jp-ui-font-color1: white;\n",
-       "                    --jp-layout-color2: #454545;\n",
-       "                    background-color: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-dark .jupyter-button {\n",
-       "                    --jp-layout-color3: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab {\n",
-       "                    background-color: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab .jupyter-button {\n",
-       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "            </style>\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-03-27 09:07:33,876 - Reflectance_Stats - INFO - Reflectance Stats initialized.\n",
-      "2026-03-27 09:07:33,877 - Reflectance_Data - INFO - Starting thermal data fetch for Landsat 8 Top-of-atmosphere reflectance\n",
-      "2026-03-27 09:07:33,877 - Reflectance_Data - INFO - Date range: 2017-01-01 to 2017-12-31\n",
-      "2026-03-27 09:07:33,878 - Reflectance_Data - INFO - Cloud cover threshold: 40%\n",
-      "2026-03-27 09:07:33,879 - Reflectance_Data - INFO - Fast mode enabled - detailed statistics will not be computed\n",
-      "2026-03-27 09:07:33,880 - Reflectance_Data - INFO - Filtered collection created (use compute_detailed_stats=True for detailed info)\n",
-      "2026-03-27 09:07:34,309 - final_Image - INFO - Creating Median composite from 5 images\n",
-      "2026-03-27 09:07:34,310 - final_Image - INFO - Composite clipped to AOI\n",
-      "2026-03-27 09:07:35,595 - final_Image - INFO - Composite created from 2017-05-05 to 2017-08-09\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d8ec17b064674c5b8edba0e1b126c6ad",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map(center=[-4.117597821329865, 103.26638606871309], controls=(WidgetControl(options=['position', 'transparent…"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "#retive thermal bands from TOA\n",
     "thermal_bands, thermal_stats = optical_reflectance.get_thermal_bands(aoi, start, end, cloud_cover=40, compute_detailed_stats=False)\n",
@@ -635,45 +286,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "5dcdcd22",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <style>\n",
-       "                .geemap-dark {\n",
-       "                    --jp-widgets-color: white;\n",
-       "                    --jp-widgets-label-color: white;\n",
-       "                    --jp-ui-font-color1: white;\n",
-       "                    --jp-layout-color2: #454545;\n",
-       "                    background-color: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-dark .jupyter-button {\n",
-       "                    --jp-layout-color3: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab {\n",
-       "                    background-color: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab .jupyter-button {\n",
-       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "            </style>\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# #intialize the statistic class\n",
     "# stats = Reflectance_Stats()\n",
@@ -691,45 +307,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "49d212e5",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <style>\n",
-       "                .geemap-dark {\n",
-       "                    --jp-widgets-color: white;\n",
-       "                    --jp-widgets-label-color: white;\n",
-       "                    --jp-ui-font-color1: white;\n",
-       "                    --jp-layout-color2: #454545;\n",
-       "                    background-color: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-dark .jupyter-button {\n",
-       "                    --jp-layout-color3: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab {\n",
-       "                    background-color: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab .jupyter-button {\n",
-       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "            </style>\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# export_task = ee.batch.Export.image.toDrive(\n",
     "#     image=stacked_landsat,\n",
@@ -772,54 +353,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "2240e73f",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <style>\n",
-       "                .geemap-dark {\n",
-       "                    --jp-widgets-color: white;\n",
-       "                    --jp-widgets-label-color: white;\n",
-       "                    --jp-ui-font-color1: white;\n",
-       "                    --jp-layout-color2: #454545;\n",
-       "                    background-color: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-dark .jupyter-button {\n",
-       "                    --jp-layout-color3: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab {\n",
-       "                    background-color: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab .jupyter-button {\n",
-       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "            </style>\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Land Cover Classification Scheme Manager initialized!\n",
-      "Current class count: 0\n",
-      "No classes defined yet.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from luma_ge.classification_scheme import LULC_Scheme_Manager\n",
     "#Initialize the LULC Scheme Manager\n",
@@ -854,45 +391,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "2c972c28",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <style>\n",
-       "                .geemap-dark {\n",
-       "                    --jp-widgets-color: white;\n",
-       "                    --jp-widgets-label-color: white;\n",
-       "                    --jp-ui-font-color1: white;\n",
-       "                    --jp-layout-color2: #454545;\n",
-       "                    background-color: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-dark .jupyter-button {\n",
-       "                    --jp-layout-color3: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab {\n",
-       "                    background-color: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab .jupyter-button {\n",
-       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "            </style>\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# import pandas as pd\n",
     "# #Reset manager for CSV upload example\n",
@@ -917,45 +419,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "dccbff10",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <style>\n",
-       "                .geemap-dark {\n",
-       "                    --jp-widgets-color: white;\n",
-       "                    --jp-widgets-label-color: white;\n",
-       "                    --jp-ui-font-color1: white;\n",
-       "                    --jp-layout-color2: #454545;\n",
-       "                    background-color: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-dark .jupyter-button {\n",
-       "                    --jp-layout-color3: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab {\n",
-       "                    background-color: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab .jupyter-button {\n",
-       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "            </style>\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# # Process CSV upload\n",
     "# success, message = manager.process_csv_upload(df, id_col, name_col, color_col)\n",
@@ -985,45 +452,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "458a8020",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <style>\n",
-       "                .geemap-dark {\n",
-       "                    --jp-widgets-color: white;\n",
-       "                    --jp-widgets-label-color: white;\n",
-       "                    --jp-ui-font-color1: white;\n",
-       "                    --jp-layout-color2: #454545;\n",
-       "                    background-color: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-dark .jupyter-button {\n",
-       "                    --jp-layout-color3: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab {\n",
-       "                    background-color: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab .jupyter-button {\n",
-       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "            </style>\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# #Reset manager for manual input example\n",
     "# manager = LULC_Scheme_Manager()\n",
@@ -1051,53 +483,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "id": "213558d3",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <style>\n",
-       "                .geemap-dark {\n",
-       "                    --jp-widgets-color: white;\n",
-       "                    --jp-widgets-label-color: white;\n",
-       "                    --jp-ui-font-color1: white;\n",
-       "                    --jp-layout-color2: #454545;\n",
-       "                    background-color: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-dark .jupyter-button {\n",
-       "                    --jp-layout-color3: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab {\n",
-       "                    background-color: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab .jupyter-button {\n",
-       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "            </style>\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "=== Editing a Class ===\n",
-      "No classes defined yet.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Example: Edit an existing class\n",
     "print(\"=== Editing a Class ===\")\n",
@@ -1128,71 +517,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "id": "11b2702d",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <style>\n",
-       "                .geemap-dark {\n",
-       "                    --jp-widgets-color: white;\n",
-       "                    --jp-widgets-label-color: white;\n",
-       "                    --jp-ui-font-color1: white;\n",
-       "                    --jp-layout-color2: #454545;\n",
-       "                    background-color: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-dark .jupyter-button {\n",
-       "                    --jp-layout-color3: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab {\n",
-       "                    background-color: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab .jupyter-button {\n",
-       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "            </style>\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "=== Available Default Schemes ===\n",
-      "\n",
-      "RESTORE+ Project: 17 classes\n",
-      "  - ID 1: Undisturbed dry-land forest (#006400)\n",
-      "  - ID 2: Logged-over dry-land forest (#228B22)\n",
-      "  - ID 3: Undisturbed mangrove (#4169E1)\n",
-      "  - ID 4: Logged-over mangrove (#87CEEB)\n",
-      "  - ID 5: Undisturbed swamp forest (#2E8B57)\n",
-      "  - ID 6: Logged-over swamp forest (#8FBC8F)\n",
-      "  - ID 7: Agroforestry (#9ACD32)\n",
-      "  - ID 8: Plantation forest (#32CD32)\n",
-      "  - ID 9: Rubber monoculture (#8B4513)\n",
-      "  - ID 10: Oil palm monoculture (#FF8C00)\n",
-      "  - ID 11: Other monoculture (#DAA520)\n",
-      "  - ID 12: Grass/savanna (#ADFF2F)\n",
-      "  - ID 13: Shrub (#90EE90)\n",
-      "  - ID 14: Cropland (#FFFF00)\n",
-      "  - ID 15: Settlement (#FF0000)\n",
-      "  - ID 16: Cleared land (#D2B48C)\n",
-      "  - ID 17: Waterbody (#0000FF)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Reset manager for default scheme example\n",
     "manager = LULC_Scheme_Manager()\n",
@@ -1208,230 +536,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "id": "982940ad",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <style>\n",
-       "                .geemap-dark {\n",
-       "                    --jp-widgets-color: white;\n",
-       "                    --jp-widgets-label-color: white;\n",
-       "                    --jp-ui-font-color1: white;\n",
-       "                    --jp-layout-color2: #454545;\n",
-       "                    background-color: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-dark .jupyter-button {\n",
-       "                    --jp-layout-color3: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab {\n",
-       "                    background-color: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab .jupyter-button {\n",
-       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "            </style>\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "✅ Loaded RESTORE+ Project with 17 classes\n",
-      "\n",
-      "=== Current Classification Scheme ===\n",
-      " ID            Land Cover Class Color Palette\n",
-      "  1 Undisturbed dry-land forest       #006400\n",
-      "  2 Logged-over dry-land forest       #228B22\n",
-      "  3        Undisturbed mangrove       #4169E1\n",
-      "  4        Logged-over mangrove       #87CEEB\n",
-      "  5    Undisturbed swamp forest       #2E8B57\n",
-      "  6    Logged-over swamp forest       #8FBC8F\n",
-      "  7                Agroforestry       #9ACD32\n",
-      "  8           Plantation forest       #32CD32\n",
-      "  9          Rubber monoculture       #8B4513\n",
-      " 10        Oil palm monoculture       #FF8C00\n",
-      " 11           Other monoculture       #DAA520\n",
-      " 12               Grass/savanna       #ADFF2F\n",
-      " 13                       Shrub       #90EE90\n",
-      " 14                    Cropland       #FFFF00\n",
-      " 15                  Settlement       #FF0000\n",
-      " 16                Cleared land       #D2B48C\n",
-      " 17                   Waterbody       #0000FF\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>ID</th>\n",
-       "      <th>Land Cover Class</th>\n",
-       "      <th>Color Palette</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>1</td>\n",
-       "      <td>Undisturbed dry-land forest</td>\n",
-       "      <td>#006400</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>2</td>\n",
-       "      <td>Logged-over dry-land forest</td>\n",
-       "      <td>#228B22</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>3</td>\n",
-       "      <td>Undisturbed mangrove</td>\n",
-       "      <td>#4169E1</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>4</td>\n",
-       "      <td>Logged-over mangrove</td>\n",
-       "      <td>#87CEEB</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>5</td>\n",
-       "      <td>Undisturbed swamp forest</td>\n",
-       "      <td>#2E8B57</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>6</td>\n",
-       "      <td>Logged-over swamp forest</td>\n",
-       "      <td>#8FBC8F</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>6</th>\n",
-       "      <td>7</td>\n",
-       "      <td>Agroforestry</td>\n",
-       "      <td>#9ACD32</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>7</th>\n",
-       "      <td>8</td>\n",
-       "      <td>Plantation forest</td>\n",
-       "      <td>#32CD32</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>8</th>\n",
-       "      <td>9</td>\n",
-       "      <td>Rubber monoculture</td>\n",
-       "      <td>#8B4513</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>9</th>\n",
-       "      <td>10</td>\n",
-       "      <td>Oil palm monoculture</td>\n",
-       "      <td>#FF8C00</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>10</th>\n",
-       "      <td>11</td>\n",
-       "      <td>Other monoculture</td>\n",
-       "      <td>#DAA520</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>11</th>\n",
-       "      <td>12</td>\n",
-       "      <td>Grass/savanna</td>\n",
-       "      <td>#ADFF2F</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>12</th>\n",
-       "      <td>13</td>\n",
-       "      <td>Shrub</td>\n",
-       "      <td>#90EE90</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>13</th>\n",
-       "      <td>14</td>\n",
-       "      <td>Cropland</td>\n",
-       "      <td>#FFFF00</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>14</th>\n",
-       "      <td>15</td>\n",
-       "      <td>Settlement</td>\n",
-       "      <td>#FF0000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>15</th>\n",
-       "      <td>16</td>\n",
-       "      <td>Cleared land</td>\n",
-       "      <td>#D2B48C</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>16</th>\n",
-       "      <td>17</td>\n",
-       "      <td>Waterbody</td>\n",
-       "      <td>#0000FF</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "    ID             Land Cover Class Color Palette\n",
-       "0    1  Undisturbed dry-land forest       #006400\n",
-       "1    2  Logged-over dry-land forest       #228B22\n",
-       "2    3         Undisturbed mangrove       #4169E1\n",
-       "3    4         Logged-over mangrove       #87CEEB\n",
-       "4    5     Undisturbed swamp forest       #2E8B57\n",
-       "5    6     Logged-over swamp forest       #8FBC8F\n",
-       "6    7                 Agroforestry       #9ACD32\n",
-       "7    8            Plantation forest       #32CD32\n",
-       "8    9           Rubber monoculture       #8B4513\n",
-       "9   10         Oil palm monoculture       #FF8C00\n",
-       "10  11            Other monoculture       #DAA520\n",
-       "11  12                Grass/savanna       #ADFF2F\n",
-       "12  13                        Shrub       #90EE90\n",
-       "13  14                     Cropland       #FFFF00\n",
-       "14  15                   Settlement       #FF0000\n",
-       "15  16                 Cleared land       #D2B48C\n",
-       "16  17                    Waterbody       #0000FF"
-      ]
-     },
-     "execution_count": 19,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Load the RESTORE+ default scheme\n",
     "scheme_name = \"RESTORE+ Project\"\n",
@@ -1456,52 +564,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "id": "8cce5575",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <style>\n",
-       "                .geemap-dark {\n",
-       "                    --jp-widgets-color: white;\n",
-       "                    --jp-widgets-label-color: white;\n",
-       "                    --jp-ui-font-color1: white;\n",
-       "                    --jp-layout-color2: #454545;\n",
-       "                    background-color: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-dark .jupyter-button {\n",
-       "                    --jp-layout-color3: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab {\n",
-       "                    background-color: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab .jupyter-button {\n",
-       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "            </style>\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'scheme_name': 'RESTORE+ Project', 'classes_of_interest': [1]}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "manager = LULC_Scheme_Manager()\n",
     "manager.load_default_scheme(\"RESTORE+ Project\")\n",
@@ -1525,73 +591,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "id": "fecc7b3e",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <style>\n",
-       "                .geemap-dark {\n",
-       "                    --jp-widgets-color: white;\n",
-       "                    --jp-widgets-label-color: white;\n",
-       "                    --jp-ui-font-color1: white;\n",
-       "                    --jp-layout-color2: #454545;\n",
-       "                    background-color: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-dark .jupyter-button {\n",
-       "                    --jp-layout-color3: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab {\n",
-       "                    background-color: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab .jupyter-button {\n",
-       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "            </style>\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "=== Export Classification Scheme ===\n",
-      "Classification DataFrame:\n",
-      "    ID             Land Cover Class Color Palette\n",
-      "0    1  Undisturbed dry-land forest       #006400\n",
-      "1    2  Logged-over dry-land forest       #228B22\n",
-      "2    3         Undisturbed mangrove       #4169E1\n",
-      "3    4         Logged-over mangrove       #87CEEB\n",
-      "4    5     Undisturbed swamp forest       #2E8B57\n",
-      "5    6     Logged-over swamp forest       #8FBC8F\n",
-      "6    7                 Agroforestry       #9ACD32\n",
-      "7    8            Plantation forest       #32CD32\n",
-      "8    9           Rubber monoculture       #8B4513\n",
-      "9   10         Oil palm monoculture       #FF8C00\n",
-      "10  11            Other monoculture       #DAA520\n",
-      "11  12                Grass/savanna       #ADFF2F\n",
-      "12  13                        Shrub       #90EE90\n",
-      "13  14                     Cropland       #FFFF00\n",
-      "14  15                   Settlement       #FF0000\n",
-      "15  16                 Cleared land       #D2B48C\n",
-      "16  17                    Waterbody       #0000FF\n",
-      "\n",
-      "✅ Classification scheme saved to: ../Selected_LC_Classification_Scheme.csv\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\"=== Export Classification Scheme ===\")\n",
     "#Convert the selected  classification scheme manager to dataframe\n",
@@ -1634,57 +637,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "id": "d956b21d",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <style>\n",
-       "                .geemap-dark {\n",
-       "                    --jp-widgets-color: white;\n",
-       "                    --jp-widgets-label-color: white;\n",
-       "                    --jp-ui-font-color1: white;\n",
-       "                    --jp-layout-color2: #454545;\n",
-       "                    background-color: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-dark .jupyter-button {\n",
-       "                    --jp-layout-color3: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab {\n",
-       "                    background-color: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab .jupyter-button {\n",
-       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "            </style>\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "=== Checking Prerequisites ===\n",
-      "✅ AOI from Module 1 is available\n",
-      "✅ Classification scheme from Module 2 is available\n",
-      "   - Number of classes: 17\n",
-      "\n",
-      "✅ All prerequisites met! You can proceed with training data collection.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\"=== Checking Prerequisites ===\")\n",
     "#Load from previous module\n",
@@ -1717,45 +673,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "id": "ae398a78",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <style>\n",
-       "                .geemap-dark {\n",
-       "                    --jp-widgets-color: white;\n",
-       "                    --jp-widgets-label-color: white;\n",
-       "                    --jp-ui-font-color1: white;\n",
-       "                    --jp-layout-color2: #454545;\n",
-       "                    background-color: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-dark .jupyter-button {\n",
-       "                    --jp-layout-color3: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab {\n",
-       "                    background-color: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab .jupyter-button {\n",
-       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "            </style>\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Modul 3a \n",
     "# Import modules and functions\n",
@@ -1774,45 +695,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "id": "7411b55c",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <style>\n",
-       "                .geemap-dark {\n",
-       "                    --jp-widgets-color: white;\n",
-       "                    --jp-widgets-label-color: white;\n",
-       "                    --jp-ui-font-color1: white;\n",
-       "                    --jp-layout-color2: #454545;\n",
-       "                    background-color: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-dark .jupyter-button {\n",
-       "                    --jp-layout-color3: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab {\n",
-       "                    background-color: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab .jupyter-button {\n",
-       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "            </style>\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# # ----- Data Input -----\n",
     "# # 1. Decision to upload data\n",
@@ -1832,45 +718,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "id": "f745ae9d",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <style>\n",
-       "                .geemap-dark {\n",
-       "                    --jp-widgets-color: white;\n",
-       "                    --jp-widgets-label-color: white;\n",
-       "                    --jp-ui-font-color1: white;\n",
-       "                    --jp-layout-color2: #454545;\n",
-       "                    background-color: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-dark .jupyter-button {\n",
-       "                    --jp-layout-color3: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab {\n",
-       "                    background-color: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab .jupyter-button {\n",
-       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "            </style>\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# # ----- System response 3.2.a -----\n",
     "# # Set class field\n",
@@ -1926,214 +777,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "id": "4869adce",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <style>\n",
-       "                .geemap-dark {\n",
-       "                    --jp-widgets-color: white;\n",
-       "                    --jp-widgets-label-color: white;\n",
-       "                    --jp-ui-font-color1: white;\n",
-       "                    --jp-layout-color2: #454545;\n",
-       "                    background-color: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-dark .jupyter-button {\n",
-       "                    --jp-layout-color3: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab {\n",
-       "                    background-color: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab .jupyter-button {\n",
-       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "            </style>\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-03-27 09:07:37,458 - luma_ge.sample_data - INFO - Loading training data from EE asset: projects/ee-rg2icraf/assets/Indonesia_lulc_Sample\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " Loading default reference training data...\n",
-      "Column 'Land Cover Class' renamed to 'LULC_Type'\n",
-      "Loading reference training data from Earth Engine...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-03-27 09:07:38,338 - googleapiclient.http - WARNING - Sleeping 1.65 seconds before retry 1 of 5 for request: POST https://earthengine.googleapis.com/v1/projects/ee-epstm2024/value:compute?prettyPrint=false&alt=json, after 503\n",
-      "2026-03-27 09:07:42,582 - luma_ge.sample_data - INFO - Initial feature count: 1130000\n",
-      "2026-03-27 09:07:42,583 - luma_ge.sample_data - INFO - Filtering by AOI bounds...\n",
-      "2026-03-27 09:07:42,584 - luma_ge.sample_data - INFO - AOI geometry type: <class 'ee.geometry.Geometry'>\n",
-      "2026-03-27 09:07:44,257 - luma_ge.sample_data - INFO - Features after AOI filter: 99\n",
-      "2026-03-27 09:07:44,259 - luma_ge.sample_data - INFO - Converting to GeoDataFrame...\n",
-      "2026-03-27 09:07:45,638 - luma_ge.sample_data - INFO - Collection size: 99\n",
-      "2026-03-27 09:07:45,639 - luma_ge.sample_data - INFO - Collection size (99) is within normal limits, loading directly\n",
-      "2026-03-27 09:07:50,362 - googleapiclient.http - WARNING - Sleeping 1.99 seconds before retry 1 of 5 for request: POST https://earthengine.googleapis.com/v1/projects/ee-epstm2024/value:compute?prettyPrint=false&alt=json, after ('Connection aborted.', ConnectionAbortedError(10053, 'An established connection was aborted by the software in your host machine', None, 10053, None))\n",
-      "2026-03-27 09:07:52,408 - googleapiclient.http - WARNING - Sleeping 0.45 seconds before retry 2 of 5 for request: POST https://earthengine.googleapis.com/v1/projects/ee-epstm2024/value:compute?prettyPrint=false&alt=json, after HTTPSConnectionPool(host='earthengine.googleapis.com', port=443): Max retries exceeded with url: /v1/projects/ee-epstm2024/value:compute?prettyPrint=false&alt=json (Caused by NameResolutionError(\"<urllib3.connection.HTTPSConnection object at 0x00000163226E79D0>: Failed to resolve 'earthengine.googleapis.com' ([Errno 11001] getaddrinfo failed)\"))\n",
-      "2026-03-27 09:07:55,759 - luma_ge.sample_data - INFO - Features to convert: 99\n",
-      "2026-03-27 09:07:55,763 - luma_ge.sample_data - INFO - Successfully processed 99 features\n",
-      "2026-03-27 09:07:55,782 - luma_ge.sample_data - INFO - Unique classes in training data: [ 1  2  7  9 13 14 15]\n",
-      "2026-03-27 09:07:55,785 - luma_ge.sample_data - INFO - Class counts: {7: 42, 1: 26, 14: 11, 2: 10, 13: 4, 9: 3, 15: 3}\n",
-      "2026-03-27 09:07:55,786 - luma_ge.sample_data - INFO - Validating classes with use_class_ids=True\n",
-      "2026-03-27 09:07:55,787 - luma_ge.sample_data - INFO - Class field: kelas\n",
-      "2026-03-27 09:07:55,788 - luma_ge.sample_data - INFO - Training data type: <class 'geopandas.geodataframe.GeoDataFrame'>\n",
-      "2026-03-27 09:07:55,789 - luma_ge.sample_data - INFO - Landcover DF columns: ['ID', 'LULC_Type', 'Color Palette']\n",
-      "2026-03-27 09:07:55,789 - luma_ge.sample_data - INFO - Valid IDs in landcover_df: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]\n",
-      "2026-03-27 09:07:55,790 - luma_ge.sample_data - INFO - Processing GeoDataFrame with 99 features\n",
-      "2026-03-27 09:07:55,792 - luma_ge.sample_data - INFO - Unique classes in training data: [ 1  2  7  9 13 14 15]\n",
-      "2026-03-27 09:07:55,793 - luma_ge.sample_data - INFO - Valid class ID: 1\n",
-      "2026-03-27 09:07:55,793 - luma_ge.sample_data - INFO - Valid class ID: 2\n",
-      "2026-03-27 09:07:55,794 - luma_ge.sample_data - INFO - Valid class ID: 7\n",
-      "2026-03-27 09:07:55,795 - luma_ge.sample_data - INFO - Valid class ID: 9\n",
-      "2026-03-27 09:07:55,796 - luma_ge.sample_data - INFO - Valid class ID: 13\n",
-      "2026-03-27 09:07:55,800 - luma_ge.sample_data - INFO - Valid class ID: 14\n",
-      "2026-03-27 09:07:55,801 - luma_ge.sample_data - INFO - Valid class ID: 15\n",
-      "2026-03-27 09:07:55,802 - luma_ge.sample_data - INFO - Valid classes: [np.int64(1), np.int64(2), np.int64(7), np.int64(9), np.int64(13), np.int64(14), np.int64(15)]\n",
-      "2026-03-27 09:07:55,803 - luma_ge.sample_data - INFO - Invalid classes: []\n",
-      "2026-03-27 09:07:55,805 - luma_ge.sample_data - INFO - Features after class validation: 99\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Processing and validating reference data...\n",
-      "✅ Reference training data loaded and processed successfully!\n",
-      "Total samples: 99\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>ID</th>\n",
-       "      <th>LULC_class</th>\n",
-       "      <th>Sample_Count</th>\n",
-       "      <th>Percentage</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>7</td>\n",
-       "      <td>Agroforestry</td>\n",
-       "      <td>42</td>\n",
-       "      <td>42.424242</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>1</td>\n",
-       "      <td>Undisturbed dry-land forest</td>\n",
-       "      <td>26</td>\n",
-       "      <td>26.262626</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>14</td>\n",
-       "      <td>Cropland</td>\n",
-       "      <td>11</td>\n",
-       "      <td>11.111111</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>2</td>\n",
-       "      <td>Logged-over dry-land forest</td>\n",
-       "      <td>10</td>\n",
-       "      <td>10.101010</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>13</td>\n",
-       "      <td>Shrub</td>\n",
-       "      <td>4</td>\n",
-       "      <td>4.040404</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>9</td>\n",
-       "      <td>Rubber monoculture</td>\n",
-       "      <td>3</td>\n",
-       "      <td>3.030303</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>6</th>\n",
-       "      <td>15</td>\n",
-       "      <td>Settlement</td>\n",
-       "      <td>3</td>\n",
-       "      <td>3.030303</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "   ID                   LULC_class  Sample_Count  Percentage\n",
-       "0   7                 Agroforestry            42   42.424242\n",
-       "1   1  Undisturbed dry-land forest            26   26.262626\n",
-       "2  14                     Cropland            11   11.111111\n",
-       "3   2  Logged-over dry-land forest            10   10.101010\n",
-       "4  13                        Shrub             4    4.040404\n",
-       "5   9           Rubber monoculture             3    3.030303\n",
-       "6  15                   Settlement             3    3.030303"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Validation Results:\n",
-      "- Total points loaded: 99\n",
-      "- Points after class filter: 99\n",
-      "- Valid points (within AOI): 99\n",
-      "- Invalid classes: 0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\" Loading default reference training data...\")\n",
     "TrainEePath = 'projects/ee-rg2icraf/assets/Indonesia_lulc_Sample'\n",
@@ -2216,45 +863,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "id": "e1785681",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <style>\n",
-       "                .geemap-dark {\n",
-       "                    --jp-widgets-color: white;\n",
-       "                    --jp-widgets-label-color: white;\n",
-       "                    --jp-ui-font-color1: white;\n",
-       "                    --jp-layout-color2: #454545;\n",
-       "                    background-color: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-dark .jupyter-button {\n",
-       "                    --jp-layout-color3: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab {\n",
-       "                    background-color: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab .jupyter-button {\n",
-       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "            </style>\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "#Import the sample quality functions\n",
     "from luma_ge.sample_data_quality import sample_quality, spectral_plotter\n",
@@ -2272,45 +884,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "id": "7fcd6b98",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <style>\n",
-       "                .geemap-dark {\n",
-       "                    --jp-widgets-color: white;\n",
-       "                    --jp-widgets-label-color: white;\n",
-       "                    --jp-ui-font-color1: white;\n",
-       "                    --jp-layout-color2: #454545;\n",
-       "                    background-color: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-dark .jupyter-button {\n",
-       "                    --jp-layout-color3: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab {\n",
-       "                    background-color: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab .jupyter-button {\n",
-       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "            </style>\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# roi_path = '../data/Training_Sumsel_Data.shp'\n",
     "# labeled_roi = geemap.shp_to_ee('../data/Training_Sumsel_Data.shp')\n",
@@ -2333,45 +910,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "id": "6f87c8bb",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <style>\n",
-       "                .geemap-dark {\n",
-       "                    --jp-widgets-color: white;\n",
-       "                    --jp-widgets-label-color: white;\n",
-       "                    --jp-ui-font-color1: white;\n",
-       "                    --jp-layout-color2: #454545;\n",
-       "                    background-color: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-dark .jupyter-button {\n",
-       "                    --jp-layout-color3: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab {\n",
-       "                    background-color: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab .jupyter-button {\n",
-       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "            </style>\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# #Sample statistic (pixel value extracted from the imagery)\n",
     "# pixel_stats = analyzer.sample_pixel_stats(pixel_extract)\n",
@@ -2381,45 +923,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "id": "fb8effda",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <style>\n",
-       "                .geemap-dark {\n",
-       "                    --jp-widgets-color: white;\n",
-       "                    --jp-widgets-label-color: white;\n",
-       "                    --jp-ui-font-color1: white;\n",
-       "                    --jp-layout-color2: #454545;\n",
-       "                    background-color: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-dark .jupyter-button {\n",
-       "                    --jp-layout-color3: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab {\n",
-       "                    background-color: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab .jupyter-button {\n",
-       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "            </style>\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# #Perform separability Analysis (iether using Transformed Divergence or Jeffries Matutista )\n",
     "# separability_analysis = analyzer.get_separability_df(pixel_extract, method='TD')\n",
@@ -2428,45 +935,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "id": "e4dad481",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <style>\n",
-       "                .geemap-dark {\n",
-       "                    --jp-widgets-color: white;\n",
-       "                    --jp-widgets-label-color: white;\n",
-       "                    --jp-ui-font-color1: white;\n",
-       "                    --jp-layout-color2: #454545;\n",
-       "                    background-color: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-dark .jupyter-button {\n",
-       "                    --jp-layout-color3: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab {\n",
-       "                    background-color: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab .jupyter-button {\n",
-       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "            </style>\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# #Get the lowest separability\n",
     "# lowest_sep = analyzer.lowest_separability(pixel_extract)\n",
@@ -2475,45 +947,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "id": "3347eecf",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <style>\n",
-       "                .geemap-dark {\n",
-       "                    --jp-widgets-color: white;\n",
-       "                    --jp-widgets-label-color: white;\n",
-       "                    --jp-ui-font-color1: white;\n",
-       "                    --jp-layout-color2: #454545;\n",
-       "                    background-color: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-dark .jupyter-button {\n",
-       "                    --jp-layout-color3: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab {\n",
-       "                    background-color: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab .jupyter-button {\n",
-       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "            </style>\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# # Overall separability summary\n",
     "# sep_summary = analyzer.sum_separability(pixel_extract)\n",
@@ -2531,45 +968,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "id": "36d23c90",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <style>\n",
-       "                .geemap-dark {\n",
-       "                    --jp-widgets-color: white;\n",
-       "                    --jp-widgets-label-color: white;\n",
-       "                    --jp-ui-font-color1: white;\n",
-       "                    --jp-layout-color2: #454545;\n",
-       "                    background-color: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-dark .jupyter-button {\n",
-       "                    --jp-layout-color3: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab {\n",
-       "                    background-color: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab .jupyter-button {\n",
-       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "            </style>\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# #Box plot to detect outlier\n",
     "# ploter = spectral_plotter(analyzer)\n",
@@ -2580,45 +982,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": null,
    "id": "f5d4625e",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <style>\n",
-       "                .geemap-dark {\n",
-       "                    --jp-widgets-color: white;\n",
-       "                    --jp-widgets-label-color: white;\n",
-       "                    --jp-ui-font-color1: white;\n",
-       "                    --jp-layout-color2: #454545;\n",
-       "                    background-color: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-dark .jupyter-button {\n",
-       "                    --jp-layout-color3: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab {\n",
-       "                    background-color: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab .jupyter-button {\n",
-       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "            </style>\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# #static scatter plot\n",
     "# stat_plot = ploter.static_scatter_plot(pixel_extract, x_band='NIR', y_band='RED', add_ellipse=True)"
@@ -2626,45 +993,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": null,
    "id": "d21da65f",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <style>\n",
-       "                .geemap-dark {\n",
-       "                    --jp-widgets-color: white;\n",
-       "                    --jp-widgets-label-color: white;\n",
-       "                    --jp-ui-font-color1: white;\n",
-       "                    --jp-layout-color2: #454545;\n",
-       "                    background-color: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-dark .jupyter-button {\n",
-       "                    --jp-layout-color3: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab {\n",
-       "                    background-color: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab .jupyter-button {\n",
-       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "            </style>\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# #3D scatter plot\n",
     "# multi_d_scater = ploter.scatter_plot_3d(pixel_extract)\n",
@@ -2689,45 +1021,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": null,
    "id": "bac11b30",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <style>\n",
-       "                .geemap-dark {\n",
-       "                    --jp-widgets-color: white;\n",
-       "                    --jp-widgets-label-color: white;\n",
-       "                    --jp-ui-font-color1: white;\n",
-       "                    --jp-layout-color2: #454545;\n",
-       "                    background-color: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-dark .jupyter-button {\n",
-       "                    --jp-layout-color3: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab {\n",
-       "                    background-color: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab .jupyter-button {\n",
-       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "            </style>\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from luma_ge.classification import FeatureExtraction, Generate_LULC\n",
     "import numpy as np\n",
@@ -2745,60 +1042,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": null,
    "id": "6253ee61",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <style>\n",
-       "                .geemap-dark {\n",
-       "                    --jp-widgets-color: white;\n",
-       "                    --jp-widgets-label-color: white;\n",
-       "                    --jp-ui-font-color1: white;\n",
-       "                    --jp-layout-color2: #454545;\n",
-       "                    background-color: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-dark .jupyter-button {\n",
-       "                    --jp-layout-color3: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab {\n",
-       "                    background-color: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab .jupyter-button {\n",
-       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "            </style>\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-03-27 09:07:58,446 - pyogrio._io - INFO - Created 99 records\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Stratified Random Split Training Pixel Size: 51\n",
-      "Stratified Random Split Testing Pixel Size: 48\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "labeled_roi = geemap.gdf_to_ee(TrainDataFinal)\n",
     "\n",
@@ -2810,54 +1057,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": null,
    "id": "943ac0d8",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <style>\n",
-       "                .geemap-dark {\n",
-       "                    --jp-widgets-color: white;\n",
-       "                    --jp-widgets-label-color: white;\n",
-       "                    --jp-ui-font-color1: white;\n",
-       "                    --jp-layout-color2: #454545;\n",
-       "                    background-color: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-dark .jupyter-button {\n",
-       "                    --jp-layout-color3: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab {\n",
-       "                    background-color: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab .jupyter-button {\n",
-       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "            </style>\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Performing Classification...\n",
-      "Evaluating model performance...\n",
-      "✓ Model evaluation completed\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "classifier = Generate_LULC()\n",
     "print(\"Performing Classification...\")\n",
@@ -2882,52 +1085,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": null,
    "id": "47e81ae5",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <style>\n",
-       "                .geemap-dark {\n",
-       "                    --jp-widgets-color: white;\n",
-       "                    --jp-widgets-label-color: white;\n",
-       "                    --jp-ui-font-color1: white;\n",
-       "                    --jp-layout-color2: #454545;\n",
-       "                    background-color: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-dark .jupyter-button {\n",
-       "                    --jp-layout-color3: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab {\n",
-       "                    background-color: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab .jupyter-button {\n",
-       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "            </style>\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'classification': {'1': 85827.52941176463, '2': 73377.44313725489, '7': 490033.92549019546}}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "orig_hist = classification_map.reduceRegion(\n",
     "    reducer=ee.Reducer.frequencyHistogram(),\n",
@@ -2949,45 +1110,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": null,
    "id": "592b48ea",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <style>\n",
-       "                .geemap-dark {\n",
-       "                    --jp-widgets-color: white;\n",
-       "                    --jp-widgets-label-color: white;\n",
-       "                    --jp-ui-font-color1: white;\n",
-       "                    --jp-layout-color2: #454545;\n",
-       "                    background-color: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-dark .jupyter-button {\n",
-       "                    --jp-layout-color3: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab {\n",
-       "                    background-color: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab .jupyter-button {\n",
-       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "            </style>\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# # Display accuracy results\n",
     "# print(\"=== Model Performance Summary ===\")\n",
@@ -3012,45 +1138,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": null,
    "id": "a32e88e6",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <style>\n",
-       "                .geemap-dark {\n",
-       "                    --jp-widgets-color: white;\n",
-       "                    --jp-widgets-label-color: white;\n",
-       "                    --jp-ui-font-color1: white;\n",
-       "                    --jp-layout-color2: #454545;\n",
-       "                    background-color: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-dark .jupyter-button {\n",
-       "                    --jp-layout-color3: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab {\n",
-       "                    background-color: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab .jupyter-button {\n",
-       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "            </style>\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# # Visualize confusion matrix\n",
     "# confusion_matrix = np.array(accuracy_metrics['confusion_matrix'])\n",
@@ -3068,45 +1159,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": null,
    "id": "4f7077f3",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <style>\n",
-       "                .geemap-dark {\n",
-       "                    --jp-widgets-color: white;\n",
-       "                    --jp-widgets-label-color: white;\n",
-       "                    --jp-ui-font-color1: white;\n",
-       "                    --jp-layout-color2: #454545;\n",
-       "                    background-color: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-dark .jupyter-button {\n",
-       "                    --jp-layout-color3: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab {\n",
-       "                    background-color: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab .jupyter-button {\n",
-       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "            </style>\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# # Get feature importance\n",
     "# print(\"Analyzing feature importance...\")\n",
@@ -3149,60 +1205,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": null,
    "id": "536ab3fe",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <style>\n",
-       "                .geemap-dark {\n",
-       "                    --jp-widgets-color: white;\n",
-       "                    --jp-widgets-label-color: white;\n",
-       "                    --jp-ui-font-color1: white;\n",
-       "                    --jp-layout-color2: #454545;\n",
-       "                    background-color: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-dark .jupyter-button {\n",
-       "                    --jp-layout-color3: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab {\n",
-       "                    background-color: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab .jupyter-button {\n",
-       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "            </style>\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c922db05ee01421da666e01f1373d421",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map(center=[-4.117597821329865, 103.26638606871309], controls=(WidgetControl(options=['position', 'transparent…"
-      ]
-     },
-     "execution_count": 43,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# === Load Classification Scheme ===\n",
     "scheme = pd.read_csv(\"../Selected_LC_Classification_Scheme.csv\", sep=None, engine=\"python\")\n",
@@ -3243,58 +1249,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": null,
    "id": "d20f2e1f",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <style>\n",
-       "                .geemap-dark {\n",
-       "                    --jp-widgets-color: white;\n",
-       "                    --jp-widgets-label-color: white;\n",
-       "                    --jp-ui-font-color1: white;\n",
-       "                    --jp-layout-color2: #454545;\n",
-       "                    background-color: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-dark .jupyter-button {\n",
-       "                    --jp-layout-color3: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab {\n",
-       "                    background-color: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab .jupyter-button {\n",
-       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "            </style>\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "{'histogram': {'1': 85827.52941176463, '999': 563411.3686274507},\n",
-       " 'existing_classes': [1],\n",
-       " 'missing_classes': [],\n",
-       " 'all_classes_present': True}"
-      ]
-     },
-     "execution_count": 44,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Reclassify the map\n",
     "\n",
@@ -3309,60 +1267,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": null,
    "id": "b37f21e1",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <style>\n",
-       "                .geemap-dark {\n",
-       "                    --jp-widgets-color: white;\n",
-       "                    --jp-widgets-label-color: white;\n",
-       "                    --jp-ui-font-color1: white;\n",
-       "                    --jp-layout-color2: #454545;\n",
-       "                    background-color: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-dark .jupyter-button {\n",
-       "                    --jp-layout-color3: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab {\n",
-       "                    background-color: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab .jupyter-button {\n",
-       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "            </style>\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c922db05ee01421da666e01f1373d421",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map(center=[-4.117597821329865, 103.26638606871309], controls=(WidgetControl(options=['position', 'transparent…"
-      ]
-     },
-     "execution_count": 45,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Prepare Reclassified Visualization\n",
     "\n",
@@ -3425,67 +1333,7 @@
    "execution_count": null,
    "id": "58088b84",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <style>\n",
-       "                .geemap-dark {\n",
-       "                    --jp-widgets-color: white;\n",
-       "                    --jp-widgets-label-color: white;\n",
-       "                    --jp-ui-font-color1: white;\n",
-       "                    --jp-layout-color2: #454545;\n",
-       "                    background-color: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-dark .jupyter-button {\n",
-       "                    --jp-layout-color3: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab {\n",
-       "                    background-color: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab .jupyter-button {\n",
-       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "            </style>\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Loading prebuilt map for 'RESTORE+ Project' year 2018...\n",
-      "[classify_from_prebuilt] Map resolution (m): 107.74018379157373\n",
-      "Loaded year    : 2018\n",
-      "Classes in AOI : ['Undisturbed dry-land forest', 'Logged-over dry-land forest', 'Agroforestry', 'Plantation forest', 'Rubber monoculture', 'Oil palm monoculture', 'Grass/savanna', 'Shrub', 'Cropland', 'Settlement', 'Cleared land']\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "573a2bea38b546649f7eb5ac864b59f9",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map(center=[-4.117597821329865, 103.26638606871309], controls=(WidgetControl(options=['position', 'transparent…"
-      ]
-     },
-     "execution_count": 46,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "generator = Generate_LULC()\n",
     "\n",
@@ -3543,53 +1391,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": null,
    "id": "9232a519",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <style>\n",
-       "                .geemap-dark {\n",
-       "                    --jp-widgets-color: white;\n",
-       "                    --jp-widgets-label-color: white;\n",
-       "                    --jp-ui-font-color1: white;\n",
-       "                    --jp-layout-color2: #454545;\n",
-       "                    background-color: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-dark .jupyter-button {\n",
-       "                    --jp-layout-color3: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab {\n",
-       "                    background-color: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab .jupyter-button {\n",
-       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "            </style>\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "✓ Thematic Accuracy Assessment class initialized\n",
-      "Supported metrics: ['overall_accuracy', 'kappa', 'producer_accuracy', 'user_accuracy', 'f1_scores', 'confusion_matrix']\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from luma_ge.accuracy import Thematic_Accuracy_Assessment\n",
     "#Initialize the accuracy assessment class\n",
@@ -3600,45 +1405,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": null,
    "id": "6f505ccf",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <style>\n",
-       "                .geemap-dark {\n",
-       "                    --jp-widgets-color: white;\n",
-       "                    --jp-widgets-label-color: white;\n",
-       "                    --jp-ui-font-color1: white;\n",
-       "                    --jp-layout-color2: #454545;\n",
-       "                    background-color: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-dark .jupyter-button {\n",
-       "                    --jp-layout-color3: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab {\n",
-       "                    background-color: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab .jupyter-button {\n",
-       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "            </style>\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# validation_data = geemap.shp_to_ee(\"../data/Evaluation_Sumsel_data.shp\") \n",
     "\n",
@@ -3677,54 +1447,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": null,
    "id": "8aafa6a4",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <style>\n",
-       "                .geemap-dark {\n",
-       "                    --jp-widgets-color: white;\n",
-       "                    --jp-widgets-label-color: white;\n",
-       "                    --jp-ui-font-color1: white;\n",
-       "                    --jp-layout-color2: #454545;\n",
-       "                    background-color: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-dark .jupyter-button {\n",
-       "                    --jp-layout-color3: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab {\n",
-       "                    background-color: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab .jupyter-button {\n",
-       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "            </style>\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "✓ Classification image loaded\n",
-      "✓ Validation collection loaded: users/hadicu06/IIASA/RESTORE/accuracy_assessment_samples/stratified_samples_targ2percSEOverallAcc_localExpertsInterpreters\n",
-      "  → 1 validation features found\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "validation_asset = \"users/hadicu06/IIASA/RESTORE/accuracy_assessment_samples/stratified_samples_targ2percSEOverallAcc_localExpertsInterpreters\" # validation dataset used for thematic accuracy assessment for R+ \n",
     "validation_fc = ee.FeatureCollection(validation_asset).filterBounds(aoi)\n",
@@ -3745,59 +1471,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": null,
    "id": "51959dae",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <style>\n",
-       "                .geemap-dark {\n",
-       "                    --jp-widgets-color: white;\n",
-       "                    --jp-widgets-label-color: white;\n",
-       "                    --jp-ui-font-color1: white;\n",
-       "                    --jp-layout-color2: #454545;\n",
-       "                    background-color: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-dark .jupyter-button {\n",
-       "                    --jp-layout-color3: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab {\n",
-       "                    background-color: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab .jupyter-button {\n",
-       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "            </style>\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "── Properties ───────────────────────────────\n",
-      "  Names  : ['class', 'confidence', 'consensus_type', 'consensus_type_meaning', 'eng_name', 'gee_class_id', 'location_id', 'name', 'point_id', 'sample_id']\n",
-      "  Sample : {'class': 11, 'confidence': None, 'consensus_type': None, 'consensus_type_meaning': None, 'eng_name': None, 'gee_class_id': None, 'location_id': None, 'name': None, 'point_id': None, 'sample_id': None}\n",
-      "  Coords : lon=103.1651, lat=-4.0231\n",
-      "{'type': 'Projection', 'crs': 'EPSG:4326', 'transform': [0.0009678465381381702, 0, 94.74733685103617, 0, -0.0009678465381381702, 6.3016488098176255]}\n",
-      "{'type': 'Projection', 'crs': 'EPSG:4326', 'transform': [1, 0, 0, 0, 1, 0]}\n",
-      "1\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "first_feature   = validation_fc.first().getInfo()\n",
     "prop_names      = list(first_feature[\"properties\"].keys())\n",
@@ -3816,58 +1493,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": null,
    "id": "a0bc0de5",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <style>\n",
-       "                .geemap-dark {\n",
-       "                    --jp-widgets-color: white;\n",
-       "                    --jp-widgets-label-color: white;\n",
-       "                    --jp-ui-font-color1: white;\n",
-       "                    --jp-layout-color2: #454545;\n",
-       "                    background-color: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-dark .jupyter-button {\n",
-       "                    --jp-layout-color3: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab {\n",
-       "                    background-color: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab .jupyter-button {\n",
-       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "            </style>\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "── Count per class (class) ────────────────\n",
-      "  Class ID       Count   Share\n",
-      "  ────────────────────────────\n",
-      "  11                 1  100.0%\n",
-      "  ────────────────────────────\n",
-      "  TOTAL              1\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "class_property = 'class'   # e.g. \"CLASS_ID\"\n",
     "\n",
@@ -3895,52 +1524,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": null,
    "id": "52a711fe",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <style>\n",
-       "                .geemap-dark {\n",
-       "                    --jp-widgets-color: white;\n",
-       "                    --jp-widgets-label-color: white;\n",
-       "                    --jp-ui-font-color1: white;\n",
-       "                    --jp-layout-color2: #454545;\n",
-       "                    background-color: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-dark .jupyter-button {\n",
-       "                    --jp-layout-color3: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab {\n",
-       "                    background-color: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab .jupyter-button {\n",
-       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "            </style>\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'classification': 0.9987310701815355}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "mask_check = final_map.mask().reduceRegion(\n",
     "    reducer = ee.Reducer.mean(),\n",
@@ -3954,53 +1541,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": null,
    "id": "280096fd",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <style>\n",
-       "                .geemap-dark {\n",
-       "                    --jp-widgets-color: white;\n",
-       "                    --jp-widgets-label-color: white;\n",
-       "                    --jp-ui-font-color1: white;\n",
-       "                    --jp-layout-color2: #454545;\n",
-       "                    background-color: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-dark .jupyter-button {\n",
-       "                    --jp-layout-color3: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab {\n",
-       "                    background-color: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab .jupyter-button {\n",
-       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "            </style>\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-03-27 09:08:32,248 - luma_ge.accuracy - INFO - Starting accuracy assessment...\n",
-      "2026-03-27 09:08:35,751 - luma_ge.accuracy - INFO - Accuracy assessment completed successfully\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "success, results = accuracy_assessor.run_accuracy_assessment(\n",
     "    lcmap           = default_map,\n",

--- a/notebooks/Module_implementation.ipynb
+++ b/notebooks/Module_implementation.ipynb
@@ -494,23 +494,23 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-03-24 09:47:54,138 - Reflectance_Data - INFO - ReflectanceData initialized.\n",
-      "2026-03-24 09:47:54,140 - final_Image - INFO - final_Image creation initialized.\n",
-      "2026-03-24 09:47:54,141 - Reflectance_Data - INFO - Starting data fetch for Landsat 8 Operational Land Imager Surface Reflectance\n",
-      "2026-03-24 09:47:54,143 - Reflectance_Data - INFO - Date range: 2017-01-01 to 2017-12-31\n",
-      "2026-03-24 09:47:54,144 - Reflectance_Data - INFO - Cloud cover threshold: 40%\n",
-      "2026-03-24 09:47:54,145 - Reflectance_Data - INFO - detailed statistics will not be computed\n",
-      "2026-03-24 09:47:54,147 - Reflectance_Stats - INFO - Reflectance Stats initialized.\n",
-      "2026-03-24 09:47:54,149 - Reflectance_Data - INFO - Filtered collection created (use compute_detailed_stats=True for more information)\n",
-      "2026-03-24 09:47:54,935 - final_Image - INFO - Creating quality mosaic from 5 images using NDVI as quality metric\n",
-      "2026-03-24 09:47:54,939 - final_Image - INFO - Quality mosaic created covering AOI with best available pixels\n",
-      "2026-03-24 09:47:56,171 - final_Image - INFO - Mosaic date range: 2017-05-05 to 2017-08-09\n",
-      "2026-03-24 09:47:56,828 - final_Image - INFO - Creating Median composite from 5 images\n",
-      "2026-03-24 09:47:56,830 - final_Image - INFO - Composite clipped to AOI\n",
-      "2026-03-24 09:47:57,879 - final_Image - INFO - Composite created from 2017-05-05 to 2017-08-09\n",
-      "2026-03-24 09:47:57,880 - final_Image - INFO - Calculating data coverage within AOI...\n",
-      "2026-03-24 09:48:03,741 - final_Image - INFO - Data coverage: 92.4% (578.22 km² of 625.90 km²)\n",
-      "2026-03-24 09:48:03,742 - final_Image - INFO - Data gaps: 7.6% (47.68 km²)\n"
+      "2026-03-27 09:07:23,725 - Reflectance_Data - INFO - ReflectanceData initialized.\n",
+      "2026-03-27 09:07:23,726 - final_Image - INFO - final_Image creation initialized.\n",
+      "2026-03-27 09:07:23,728 - Reflectance_Data - INFO - Starting data fetch for Landsat 8 Operational Land Imager Surface Reflectance\n",
+      "2026-03-27 09:07:23,728 - Reflectance_Data - INFO - Date range: 2017-01-01 to 2017-12-31\n",
+      "2026-03-27 09:07:23,729 - Reflectance_Data - INFO - Cloud cover threshold: 40%\n",
+      "2026-03-27 09:07:23,729 - Reflectance_Data - INFO - detailed statistics will not be computed\n",
+      "2026-03-27 09:07:23,730 - Reflectance_Stats - INFO - Reflectance Stats initialized.\n",
+      "2026-03-27 09:07:23,730 - Reflectance_Data - INFO - Filtered collection created (use compute_detailed_stats=True for more information)\n",
+      "2026-03-27 09:07:24,233 - final_Image - INFO - Creating quality mosaic from 5 images using NDVI as quality metric\n",
+      "2026-03-27 09:07:24,236 - final_Image - INFO - Quality mosaic created covering AOI with best available pixels\n",
+      "2026-03-27 09:07:25,208 - final_Image - INFO - Mosaic date range: 2017-05-05 to 2017-08-09\n",
+      "2026-03-27 09:07:26,246 - final_Image - INFO - Creating Median composite from 5 images\n",
+      "2026-03-27 09:07:26,247 - final_Image - INFO - Composite clipped to AOI\n",
+      "2026-03-27 09:07:27,137 - final_Image - INFO - Composite created from 2017-05-05 to 2017-08-09\n",
+      "2026-03-27 09:07:27,139 - final_Image - INFO - Calculating data coverage within AOI...\n",
+      "2026-03-27 09:07:30,690 - final_Image - INFO - Data coverage: 92.4% (578.22 km² of 625.90 km²)\n",
+      "2026-03-27 09:07:30,692 - final_Image - INFO - Data gaps: 7.6% (47.68 km²)\n"
      ]
     }
    ],
@@ -586,21 +586,21 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-03-24 09:48:07,358 - Reflectance_Stats - INFO - Reflectance Stats initialized.\n",
-      "2026-03-24 09:48:07,360 - Reflectance_Data - INFO - Starting thermal data fetch for Landsat 8 Top-of-atmosphere reflectance\n",
-      "2026-03-24 09:48:07,361 - Reflectance_Data - INFO - Date range: 2017-01-01 to 2017-12-31\n",
-      "2026-03-24 09:48:07,363 - Reflectance_Data - INFO - Cloud cover threshold: 40%\n",
-      "2026-03-24 09:48:07,364 - Reflectance_Data - INFO - Fast mode enabled - detailed statistics will not be computed\n",
-      "2026-03-24 09:48:07,369 - Reflectance_Data - INFO - Filtered collection created (use compute_detailed_stats=True for detailed info)\n",
-      "2026-03-24 09:48:07,787 - final_Image - INFO - Creating Median composite from 5 images\n",
-      "2026-03-24 09:48:07,790 - final_Image - INFO - Composite clipped to AOI\n",
-      "2026-03-24 09:48:09,537 - final_Image - INFO - Composite created from 2017-05-05 to 2017-08-09\n"
+      "2026-03-27 09:07:33,876 - Reflectance_Stats - INFO - Reflectance Stats initialized.\n",
+      "2026-03-27 09:07:33,877 - Reflectance_Data - INFO - Starting thermal data fetch for Landsat 8 Top-of-atmosphere reflectance\n",
+      "2026-03-27 09:07:33,877 - Reflectance_Data - INFO - Date range: 2017-01-01 to 2017-12-31\n",
+      "2026-03-27 09:07:33,878 - Reflectance_Data - INFO - Cloud cover threshold: 40%\n",
+      "2026-03-27 09:07:33,879 - Reflectance_Data - INFO - Fast mode enabled - detailed statistics will not be computed\n",
+      "2026-03-27 09:07:33,880 - Reflectance_Data - INFO - Filtered collection created (use compute_detailed_stats=True for detailed info)\n",
+      "2026-03-27 09:07:34,309 - final_Image - INFO - Creating Median composite from 5 images\n",
+      "2026-03-27 09:07:34,310 - final_Image - INFO - Composite clipped to AOI\n",
+      "2026-03-27 09:07:35,595 - final_Image - INFO - Composite created from 2017-05-05 to 2017-08-09\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "375975fc79dd4e58beb61a59ee31e9f1",
+       "model_id": "d8ec17b064674c5b8edba0e1b126c6ad",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1968,7 +1968,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-03-24 09:48:15,617 - luma_ge.sample_data - INFO - Loading training data from EE asset: projects/ee-rg2icraf/assets/Indonesia_lulc_Sample\n"
+      "2026-03-27 09:07:37,458 - luma_ge.sample_data - INFO - Loading training data from EE asset: projects/ee-rg2icraf/assets/Indonesia_lulc_Sample\n"
      ]
     },
     {
@@ -1984,34 +1984,37 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-03-24 09:48:19,577 - luma_ge.sample_data - INFO - Initial feature count: 1130000\n",
-      "2026-03-24 09:48:19,579 - luma_ge.sample_data - INFO - Filtering by AOI bounds...\n",
-      "2026-03-24 09:48:19,581 - luma_ge.sample_data - INFO - AOI geometry type: <class 'ee.geometry.Geometry'>\n",
-      "2026-03-24 09:48:22,305 - luma_ge.sample_data - INFO - Features after AOI filter: 99\n",
-      "2026-03-24 09:48:22,307 - luma_ge.sample_data - INFO - Converting to GeoDataFrame...\n",
-      "2026-03-24 09:48:23,809 - luma_ge.sample_data - INFO - Collection size: 99\n",
-      "2026-03-24 09:48:23,810 - luma_ge.sample_data - INFO - Collection size (99) is within normal limits, loading directly\n",
-      "2026-03-24 09:48:25,609 - luma_ge.sample_data - INFO - Features to convert: 99\n",
-      "2026-03-24 09:48:25,612 - luma_ge.sample_data - INFO - Successfully processed 99 features\n",
-      "2026-03-24 09:48:25,619 - luma_ge.sample_data - INFO - Unique classes in training data: [ 1  2  7  9 13 14 15]\n",
-      "2026-03-24 09:48:25,622 - luma_ge.sample_data - INFO - Class counts: {7: 42, 1: 26, 14: 11, 2: 10, 13: 4, 9: 3, 15: 3}\n",
-      "2026-03-24 09:48:25,623 - luma_ge.sample_data - INFO - Validating classes with use_class_ids=True\n",
-      "2026-03-24 09:48:25,624 - luma_ge.sample_data - INFO - Class field: kelas\n",
-      "2026-03-24 09:48:25,625 - luma_ge.sample_data - INFO - Training data type: <class 'geopandas.geodataframe.GeoDataFrame'>\n",
-      "2026-03-24 09:48:25,626 - luma_ge.sample_data - INFO - Landcover DF columns: ['ID', 'LULC_Type', 'Color Palette']\n",
-      "2026-03-24 09:48:25,629 - luma_ge.sample_data - INFO - Valid IDs in landcover_df: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]\n",
-      "2026-03-24 09:48:25,630 - luma_ge.sample_data - INFO - Processing GeoDataFrame with 99 features\n",
-      "2026-03-24 09:48:25,631 - luma_ge.sample_data - INFO - Unique classes in training data: [ 1  2  7  9 13 14 15]\n",
-      "2026-03-24 09:48:25,633 - luma_ge.sample_data - INFO - Valid class ID: 1\n",
-      "2026-03-24 09:48:25,635 - luma_ge.sample_data - INFO - Valid class ID: 2\n",
-      "2026-03-24 09:48:25,636 - luma_ge.sample_data - INFO - Valid class ID: 7\n",
-      "2026-03-24 09:48:25,637 - luma_ge.sample_data - INFO - Valid class ID: 9\n",
-      "2026-03-24 09:48:25,639 - luma_ge.sample_data - INFO - Valid class ID: 13\n",
-      "2026-03-24 09:48:25,640 - luma_ge.sample_data - INFO - Valid class ID: 14\n",
-      "2026-03-24 09:48:25,641 - luma_ge.sample_data - INFO - Valid class ID: 15\n",
-      "2026-03-24 09:48:25,642 - luma_ge.sample_data - INFO - Valid classes: [np.int64(1), np.int64(2), np.int64(7), np.int64(9), np.int64(13), np.int64(14), np.int64(15)]\n",
-      "2026-03-24 09:48:25,643 - luma_ge.sample_data - INFO - Invalid classes: []\n",
-      "2026-03-24 09:48:25,648 - luma_ge.sample_data - INFO - Features after class validation: 99\n"
+      "2026-03-27 09:07:38,338 - googleapiclient.http - WARNING - Sleeping 1.65 seconds before retry 1 of 5 for request: POST https://earthengine.googleapis.com/v1/projects/ee-epstm2024/value:compute?prettyPrint=false&alt=json, after 503\n",
+      "2026-03-27 09:07:42,582 - luma_ge.sample_data - INFO - Initial feature count: 1130000\n",
+      "2026-03-27 09:07:42,583 - luma_ge.sample_data - INFO - Filtering by AOI bounds...\n",
+      "2026-03-27 09:07:42,584 - luma_ge.sample_data - INFO - AOI geometry type: <class 'ee.geometry.Geometry'>\n",
+      "2026-03-27 09:07:44,257 - luma_ge.sample_data - INFO - Features after AOI filter: 99\n",
+      "2026-03-27 09:07:44,259 - luma_ge.sample_data - INFO - Converting to GeoDataFrame...\n",
+      "2026-03-27 09:07:45,638 - luma_ge.sample_data - INFO - Collection size: 99\n",
+      "2026-03-27 09:07:45,639 - luma_ge.sample_data - INFO - Collection size (99) is within normal limits, loading directly\n",
+      "2026-03-27 09:07:50,362 - googleapiclient.http - WARNING - Sleeping 1.99 seconds before retry 1 of 5 for request: POST https://earthengine.googleapis.com/v1/projects/ee-epstm2024/value:compute?prettyPrint=false&alt=json, after ('Connection aborted.', ConnectionAbortedError(10053, 'An established connection was aborted by the software in your host machine', None, 10053, None))\n",
+      "2026-03-27 09:07:52,408 - googleapiclient.http - WARNING - Sleeping 0.45 seconds before retry 2 of 5 for request: POST https://earthengine.googleapis.com/v1/projects/ee-epstm2024/value:compute?prettyPrint=false&alt=json, after HTTPSConnectionPool(host='earthengine.googleapis.com', port=443): Max retries exceeded with url: /v1/projects/ee-epstm2024/value:compute?prettyPrint=false&alt=json (Caused by NameResolutionError(\"<urllib3.connection.HTTPSConnection object at 0x00000163226E79D0>: Failed to resolve 'earthengine.googleapis.com' ([Errno 11001] getaddrinfo failed)\"))\n",
+      "2026-03-27 09:07:55,759 - luma_ge.sample_data - INFO - Features to convert: 99\n",
+      "2026-03-27 09:07:55,763 - luma_ge.sample_data - INFO - Successfully processed 99 features\n",
+      "2026-03-27 09:07:55,782 - luma_ge.sample_data - INFO - Unique classes in training data: [ 1  2  7  9 13 14 15]\n",
+      "2026-03-27 09:07:55,785 - luma_ge.sample_data - INFO - Class counts: {7: 42, 1: 26, 14: 11, 2: 10, 13: 4, 9: 3, 15: 3}\n",
+      "2026-03-27 09:07:55,786 - luma_ge.sample_data - INFO - Validating classes with use_class_ids=True\n",
+      "2026-03-27 09:07:55,787 - luma_ge.sample_data - INFO - Class field: kelas\n",
+      "2026-03-27 09:07:55,788 - luma_ge.sample_data - INFO - Training data type: <class 'geopandas.geodataframe.GeoDataFrame'>\n",
+      "2026-03-27 09:07:55,789 - luma_ge.sample_data - INFO - Landcover DF columns: ['ID', 'LULC_Type', 'Color Palette']\n",
+      "2026-03-27 09:07:55,789 - luma_ge.sample_data - INFO - Valid IDs in landcover_df: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]\n",
+      "2026-03-27 09:07:55,790 - luma_ge.sample_data - INFO - Processing GeoDataFrame with 99 features\n",
+      "2026-03-27 09:07:55,792 - luma_ge.sample_data - INFO - Unique classes in training data: [ 1  2  7  9 13 14 15]\n",
+      "2026-03-27 09:07:55,793 - luma_ge.sample_data - INFO - Valid class ID: 1\n",
+      "2026-03-27 09:07:55,793 - luma_ge.sample_data - INFO - Valid class ID: 2\n",
+      "2026-03-27 09:07:55,794 - luma_ge.sample_data - INFO - Valid class ID: 7\n",
+      "2026-03-27 09:07:55,795 - luma_ge.sample_data - INFO - Valid class ID: 9\n",
+      "2026-03-27 09:07:55,796 - luma_ge.sample_data - INFO - Valid class ID: 13\n",
+      "2026-03-27 09:07:55,800 - luma_ge.sample_data - INFO - Valid class ID: 14\n",
+      "2026-03-27 09:07:55,801 - luma_ge.sample_data - INFO - Valid class ID: 15\n",
+      "2026-03-27 09:07:55,802 - luma_ge.sample_data - INFO - Valid classes: [np.int64(1), np.int64(2), np.int64(7), np.int64(9), np.int64(13), np.int64(14), np.int64(15)]\n",
+      "2026-03-27 09:07:55,803 - luma_ge.sample_data - INFO - Invalid classes: []\n",
+      "2026-03-27 09:07:55,805 - luma_ge.sample_data - INFO - Features after class validation: 99\n"
      ]
     },
     {
@@ -2784,7 +2787,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-03-24 09:48:35,846 - pyogrio._io - INFO - Created 99 records\n"
+      "2026-03-27 09:07:58,446 - pyogrio._io - INFO - Created 99 records\n"
      ]
     },
     {
@@ -3187,7 +3190,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5d173b12d590431498a74242291f92af",
+       "model_id": "c922db05ee01421da666e01f1373d421",
        "version_major": 2,
        "version_minor": 0
       },
@@ -3347,7 +3350,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5d173b12d590431498a74242291f92af",
+       "model_id": "c922db05ee01421da666e01f1373d421",
        "version_major": 2,
        "version_minor": 0
       },
@@ -3419,7 +3422,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": null,
    "id": "58088b84",
    "metadata": {},
    "outputs": [
@@ -3461,7 +3464,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[Bypass] Loading prebuilt map for 'RESTORE+ Project' year 2018...\n",
+      "Loading prebuilt map for 'RESTORE+ Project' year 2018...\n",
+      "[classify_from_prebuilt] Map resolution (m): 107.74018379157373\n",
       "Loaded year    : 2018\n",
       "Classes in AOI : ['Undisturbed dry-land forest', 'Logged-over dry-land forest', 'Agroforestry', 'Plantation forest', 'Rubber monoculture', 'Oil palm monoculture', 'Grass/savanna', 'Shrub', 'Cropland', 'Settlement', 'Cleared land']\n"
      ]
@@ -3469,7 +3473,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "eb73bafd71b44f2e892c3c32e117c796",
+       "model_id": "573a2bea38b546649f7eb5ac864b59f9",
        "version_major": 2,
        "version_minor": 0
       },
@@ -3491,12 +3495,12 @@
     "\n",
     "if chosen_scheme in KNOWN_DEFAULT_SCHEMES:\n",
     "    # Modules 3–5 skipped entirely\n",
-    "    print(f\"[Bypass] Loading prebuilt map for '{chosen_scheme}' year {2018}...\") # Year can be dynamic based on user input in Module 1\n",
+    "    print(f\"Loading prebuilt map for '{chosen_scheme}' year {2018}...\") # Year can be dynamic based on user input in Module 1\n",
     "\n",
     "    result = generator.classify_from_prebuilt(\n",
     "        scheme_name    = chosen_scheme,\n",
     "        aoi            = aoi,\n",
-    "        year           = 2018, # make this dynamic based on user input in Module 1\n",
+    "        year           = 2020, # make this dynamic based on user input in Module 1\n",
     "        scheme_classes = manager.classes,\n",
     "    )\n",
     "\n",
@@ -3673,7 +3677,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": 49,
    "id": "8aafa6a4",
    "metadata": {},
    "outputs": [
@@ -3722,7 +3726,7 @@
     }
    ],
    "source": [
-    "validation_asset = \"users/hadicu06/IIASA/RESTORE/accuracy_assessment_samples/stratified_samples_targ2percSEOverallAcc_localExpertsInterpreters\"\n",
+    "validation_asset = \"users/hadicu06/IIASA/RESTORE/accuracy_assessment_samples/stratified_samples_targ2percSEOverallAcc_localExpertsInterpreters\" # validation dataset used for thematic accuracy assessment for R+ \n",
     "validation_fc = ee.FeatureCollection(validation_asset).filterBounds(aoi)\n",
     "default_map = final_map # R+ map\n",
     "\n",
@@ -3741,7 +3745,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": 50,
    "id": "51959dae",
    "metadata": {},
    "outputs": [
@@ -3812,7 +3816,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 51,
    "id": "a0bc0de5",
    "metadata": {},
    "outputs": [
@@ -3858,25 +3862,9 @@
       "── Count per class (class) ────────────────\n",
       "  Class ID       Count   Share\n",
       "  ────────────────────────────\n",
-      "  1                105   23.1%\n",
-      "  2                 93   20.4%\n",
-      "  3                  5    1.1%\n",
-      "  4                  5    1.1%\n",
-      "  5                 14    3.1%\n",
-      "  6                 14    3.1%\n",
-      "  7                 43    9.5%\n",
-      "  8                 10    2.2%\n",
-      "  9                 20    4.4%\n",
-      "  10                34    7.5%\n",
-      "  11                14    3.1%\n",
-      "  12                 8    1.8%\n",
-      "  13                29    6.4%\n",
-      "  14                33    7.3%\n",
-      "  15                17    3.7%\n",
-      "  16                 7    1.5%\n",
-      "  17                 4    0.9%\n",
+      "  11                 1  100.0%\n",
       "  ────────────────────────────\n",
-      "  TOTAL            455\n"
+      "  TOTAL              1\n"
      ]
     }
    ],
@@ -3907,7 +3895,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 52,
    "id": "52a711fe",
    "metadata": {},
    "outputs": [
@@ -3949,7 +3937,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'classification': 0.9987310701815354}\n"
+      "{'classification': 0.9987310701815355}\n"
      ]
     }
    ],
@@ -3966,7 +3954,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 53,
    "id": "280096fd",
    "metadata": {},
    "outputs": [
@@ -4008,8 +3996,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-03-24 10:15:50,184 - luma_ge.accuracy - INFO - Starting accuracy assessment...\n",
-      "2026-03-24 10:15:56,438 - luma_ge.accuracy - INFO - Accuracy assessment completed successfully\n"
+      "2026-03-27 09:08:32,248 - luma_ge.accuracy - INFO - Starting accuracy assessment...\n",
+      "2026-03-27 09:08:35,751 - luma_ge.accuracy - INFO - Accuracy assessment completed successfully\n"
      ]
     }
    ],
@@ -4025,141 +4013,6 @@
     "if not success:\n",
     "    raise RuntimeError(f\"Assessment failed: {results.get('error', 'unknown error')}\")\n",
     " "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9a381e2b",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <style>\n",
-       "                .geemap-dark {\n",
-       "                    --jp-widgets-color: white;\n",
-       "                    --jp-widgets-label-color: white;\n",
-       "                    --jp-ui-font-color1: white;\n",
-       "                    --jp-layout-color2: #454545;\n",
-       "                    background-color: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-dark .jupyter-button {\n",
-       "                    --jp-layout-color3: #383838;\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab {\n",
-       "                    background-color: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "\n",
-       "                .geemap-colab .jupyter-button {\n",
-       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-       "                }\n",
-       "            </style>\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "THEMATIC ACCURACY ASSESSMENT — SUMMARY\n",
-      "Validation asset: users/hadicu06/IIASA/RESTORE/accuracy_assessment_samples/stratified_samples_targ2percSEOverallAcc_localExpertsInterpreters\n",
-      "Class property: class\n",
-      "Scale: 100 m\n",
-      "Confidence level: 95%\n",
-      "Total samples: 1\n",
-      "\n",
-      "OVERALL METRICS\n",
-      "Overall Accuracy (OA):   0.00%\n",
-      "95% Confidence Interval: 0.00% – 0.00%\n",
-      "Kappa Coefficient: 0.0000\n",
-      "\n",
-      "PER-CLASS METRICS\n",
-      "ID  Class Name                  Prod. Acc  User Acc  F1 Score  Samples\n",
-      "1   1                             0.00%      0.00%      0.00%        0\n",
-      "2   2                             0.00%      0.00%      0.00%        0\n",
-      "3   3                             0.00%      0.00%      0.00%        0\n",
-      "4   4                             0.00%      0.00%      0.00%        0\n",
-      "5   5                             0.00%      0.00%      0.00%        0\n",
-      "6   6                             0.00%      0.00%      0.00%        0\n",
-      "7   7                             0.00%      0.00%      0.00%        0\n",
-      "8   8                             0.00%      0.00%      0.00%        0\n",
-      "9   9                             0.00%      0.00%      0.00%        0\n",
-      "10  10                            0.00%      0.00%      0.00%        0\n",
-      "11  11                            0.00%      0.00%      0.00%        0\n",
-      "12  12                            0.00%      0.00%      0.00%        1\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "def write_report(results: dict) -> None: # alternative for format_accuracy_summary\n",
-    "    \"\"\"\n",
-    "    Print a simplified plain-text accuracy report.\n",
-    "    Derives everything from the results dict alone — no CONFIG dependency.\n",
-    "    \"\"\"\n",
-    "    # ── Derive display values from results dict ───────────────────────────────\n",
-    "    # class_ids and class_names are injected into results in Cell 5 below;\n",
-    "    # fall back to integer indices if they were never set.\n",
-    "    n_classes    = len(results[\"confusion_matrix\"])\n",
-    "    class_ids    = results.get(\"class_ids\",   list(range(n_classes)))\n",
-    "    class_names  = results.get(\"class_names\", [str(i) for i in class_ids])\n",
-    "\n",
-    "    cm           = results[\"confusion_matrix\"]\n",
-    "    oa           = results[\"overall_accuracy\"]\n",
-    "    ci_lo, ci_hi = results[\"overall_accuracy_ci\"]\n",
-    "    conf_pct     = int(results[\"confidence_level\"] * 100)\n",
-    "    row_sums     = [sum(cm[i]) for i in range(n_classes)]\n",
-    "\n",
-    "    lines = []\n",
-    "    a = lines.append\n",
-    "\n",
-    "    a(\"THEMATIC ACCURACY ASSESSMENT — SUMMARY\")\n",
-    "    a(f\"Validation asset: {validation_asset}\")\n",
-    "    a(f\"Class property: {class_property}\")\n",
-    "    a(f\"Scale: {results['scale']} m\")\n",
-    "    a(f\"Confidence level: {conf_pct}%\")\n",
-    "    a(f\"Total samples: {results['n_total']}\")\n",
-    "    a(\"\")\n",
-    "\n",
-    "    a(\"OVERALL METRICS\")\n",
-    "    a(f\"Overall Accuracy (OA): {oa * 100:6.2f}%\")\n",
-    "    a(f\"{conf_pct}% Confidence Interval: {ci_lo * 100:.2f}% – {ci_hi * 100:.2f}%\")\n",
-    "    a(f\"Kappa Coefficient: {results['kappa']:.4f}\")\n",
-    "    a(\"\")\n",
-    "\n",
-    "    a(\"PER-CLASS METRICS\")\n",
-    "    a(\"ID  Class Name                  Prod. Acc  User Acc  F1 Score  Samples\")\n",
-    "    for i in range(n_classes):\n",
-    "        a(\n",
-    "            f\"{class_ids[i]:<3} {class_names[i]:<25}\"\n",
-    "            f\"{results['producer_accuracy'][i] * 100:>9.2f}%  \"\n",
-    "            f\"{results['user_accuracy'][i]     * 100:>8.2f}%  \"\n",
-    "            f\"{results['f1_scores'][i]         * 100:>8.2f}%  \"\n",
-    "            f\"{row_sums[i]:>7}\"\n",
-    "        )\n",
-    "    a(\"\")\n",
-    "\n",
-    "    text = \"\\n\".join(lines)\n",
-    "    print(text)\n",
-    "\n",
-    "\n",
-    "# ── Attach class labels to results before writing ─────────────────────────────\n",
-    "# raw_counts was built in the inspection cell; keys are strings from EE\n",
-    "results[\"class_ids\"]   = sorted(int(k) for k in raw_counts.keys())\n",
-    "results[\"class_names\"] = [str(i) for i in results[\"class_ids\"]]  # replace with names if you have them\n",
-    "\n",
-    "# ── Print the simplified report ───────────────────────────────────────────────\n",
-    "write_report(results)\n"
    ]
   }
  ],

--- a/notebooks/Module_implementation.ipynb
+++ b/notebooks/Module_implementation.ipynb
@@ -494,23 +494,23 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-03-23 14:57:59,980 - Reflectance_Data - INFO - ReflectanceData initialized.\n",
-      "2026-03-23 14:57:59,981 - final_Image - INFO - final_Image creation initialized.\n",
-      "2026-03-23 14:57:59,982 - Reflectance_Data - INFO - Starting data fetch for Landsat 8 Operational Land Imager Surface Reflectance\n",
-      "2026-03-23 14:57:59,983 - Reflectance_Data - INFO - Date range: 2017-01-01 to 2017-12-31\n",
-      "2026-03-23 14:57:59,984 - Reflectance_Data - INFO - Cloud cover threshold: 40%\n",
-      "2026-03-23 14:57:59,984 - Reflectance_Data - INFO - detailed statistics will not be computed\n",
-      "2026-03-23 14:57:59,986 - Reflectance_Stats - INFO - Reflectance Stats initialized.\n",
-      "2026-03-23 14:57:59,987 - Reflectance_Data - INFO - Filtered collection created (use compute_detailed_stats=True for more information)\n",
-      "2026-03-23 14:58:01,193 - final_Image - INFO - Creating quality mosaic from 5 images using NDVI as quality metric\n",
-      "2026-03-23 14:58:01,196 - final_Image - INFO - Quality mosaic created covering AOI with best available pixels\n",
-      "2026-03-23 14:58:03,724 - final_Image - INFO - Mosaic date range: 2017-05-05 to 2017-08-09\n",
-      "2026-03-23 14:58:04,228 - final_Image - INFO - Creating Median composite from 5 images\n",
-      "2026-03-23 14:58:04,230 - final_Image - INFO - Composite clipped to AOI\n",
-      "2026-03-23 14:58:05,152 - final_Image - INFO - Composite created from 2017-05-05 to 2017-08-09\n",
-      "2026-03-23 14:58:05,154 - final_Image - INFO - Calculating data coverage within AOI...\n",
-      "2026-03-23 14:58:10,537 - final_Image - INFO - Data coverage: 92.4% (578.22 km² of 625.90 km²)\n",
-      "2026-03-23 14:58:10,538 - final_Image - INFO - Data gaps: 7.6% (47.68 km²)\n"
+      "2026-03-24 09:47:54,138 - Reflectance_Data - INFO - ReflectanceData initialized.\n",
+      "2026-03-24 09:47:54,140 - final_Image - INFO - final_Image creation initialized.\n",
+      "2026-03-24 09:47:54,141 - Reflectance_Data - INFO - Starting data fetch for Landsat 8 Operational Land Imager Surface Reflectance\n",
+      "2026-03-24 09:47:54,143 - Reflectance_Data - INFO - Date range: 2017-01-01 to 2017-12-31\n",
+      "2026-03-24 09:47:54,144 - Reflectance_Data - INFO - Cloud cover threshold: 40%\n",
+      "2026-03-24 09:47:54,145 - Reflectance_Data - INFO - detailed statistics will not be computed\n",
+      "2026-03-24 09:47:54,147 - Reflectance_Stats - INFO - Reflectance Stats initialized.\n",
+      "2026-03-24 09:47:54,149 - Reflectance_Data - INFO - Filtered collection created (use compute_detailed_stats=True for more information)\n",
+      "2026-03-24 09:47:54,935 - final_Image - INFO - Creating quality mosaic from 5 images using NDVI as quality metric\n",
+      "2026-03-24 09:47:54,939 - final_Image - INFO - Quality mosaic created covering AOI with best available pixels\n",
+      "2026-03-24 09:47:56,171 - final_Image - INFO - Mosaic date range: 2017-05-05 to 2017-08-09\n",
+      "2026-03-24 09:47:56,828 - final_Image - INFO - Creating Median composite from 5 images\n",
+      "2026-03-24 09:47:56,830 - final_Image - INFO - Composite clipped to AOI\n",
+      "2026-03-24 09:47:57,879 - final_Image - INFO - Composite created from 2017-05-05 to 2017-08-09\n",
+      "2026-03-24 09:47:57,880 - final_Image - INFO - Calculating data coverage within AOI...\n",
+      "2026-03-24 09:48:03,741 - final_Image - INFO - Data coverage: 92.4% (578.22 km² of 625.90 km²)\n",
+      "2026-03-24 09:48:03,742 - final_Image - INFO - Data gaps: 7.6% (47.68 km²)\n"
      ]
     }
    ],
@@ -586,21 +586,21 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-03-23 14:58:15,611 - Reflectance_Stats - INFO - Reflectance Stats initialized.\n",
-      "2026-03-23 14:58:15,611 - Reflectance_Data - INFO - Starting thermal data fetch for Landsat 8 Top-of-atmosphere reflectance\n",
-      "2026-03-23 14:58:15,613 - Reflectance_Data - INFO - Date range: 2017-01-01 to 2017-12-31\n",
-      "2026-03-23 14:58:15,615 - Reflectance_Data - INFO - Cloud cover threshold: 40%\n",
-      "2026-03-23 14:58:15,616 - Reflectance_Data - INFO - Fast mode enabled - detailed statistics will not be computed\n",
-      "2026-03-23 14:58:15,617 - Reflectance_Data - INFO - Filtered collection created (use compute_detailed_stats=True for detailed info)\n",
-      "2026-03-23 14:58:16,132 - final_Image - INFO - Creating Median composite from 5 images\n",
-      "2026-03-23 14:58:16,133 - final_Image - INFO - Composite clipped to AOI\n",
-      "2026-03-23 14:58:17,123 - final_Image - INFO - Composite created from 2017-05-05 to 2017-08-09\n"
+      "2026-03-24 09:48:07,358 - Reflectance_Stats - INFO - Reflectance Stats initialized.\n",
+      "2026-03-24 09:48:07,360 - Reflectance_Data - INFO - Starting thermal data fetch for Landsat 8 Top-of-atmosphere reflectance\n",
+      "2026-03-24 09:48:07,361 - Reflectance_Data - INFO - Date range: 2017-01-01 to 2017-12-31\n",
+      "2026-03-24 09:48:07,363 - Reflectance_Data - INFO - Cloud cover threshold: 40%\n",
+      "2026-03-24 09:48:07,364 - Reflectance_Data - INFO - Fast mode enabled - detailed statistics will not be computed\n",
+      "2026-03-24 09:48:07,369 - Reflectance_Data - INFO - Filtered collection created (use compute_detailed_stats=True for detailed info)\n",
+      "2026-03-24 09:48:07,787 - final_Image - INFO - Creating Median composite from 5 images\n",
+      "2026-03-24 09:48:07,790 - final_Image - INFO - Composite clipped to AOI\n",
+      "2026-03-24 09:48:09,537 - final_Image - INFO - Composite created from 2017-05-05 to 2017-08-09\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ad7b11162e3245f48c95f9c92180ed0f",
+       "model_id": "375975fc79dd4e58beb61a59ee31e9f1",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1968,7 +1968,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-03-23 14:58:20,767 - luma_ge.sample_data - INFO - Loading training data from EE asset: projects/ee-rg2icraf/assets/Indonesia_lulc_Sample\n"
+      "2026-03-24 09:48:15,617 - luma_ge.sample_data - INFO - Loading training data from EE asset: projects/ee-rg2icraf/assets/Indonesia_lulc_Sample\n"
      ]
     },
     {
@@ -1984,34 +1984,34 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-03-23 14:58:24,089 - luma_ge.sample_data - INFO - Initial feature count: 1130000\n",
-      "2026-03-23 14:58:24,091 - luma_ge.sample_data - INFO - Filtering by AOI bounds...\n",
-      "2026-03-23 14:58:24,092 - luma_ge.sample_data - INFO - AOI geometry type: <class 'ee.geometry.Geometry'>\n",
-      "2026-03-23 14:58:25,516 - luma_ge.sample_data - INFO - Features after AOI filter: 99\n",
-      "2026-03-23 14:58:25,517 - luma_ge.sample_data - INFO - Converting to GeoDataFrame...\n",
-      "2026-03-23 14:58:27,283 - luma_ge.sample_data - INFO - Collection size: 99\n",
-      "2026-03-23 14:58:27,284 - luma_ge.sample_data - INFO - Collection size (99) is within normal limits, loading directly\n",
-      "2026-03-23 14:58:29,202 - luma_ge.sample_data - INFO - Features to convert: 99\n",
-      "2026-03-23 14:58:29,209 - luma_ge.sample_data - INFO - Successfully processed 99 features\n",
-      "2026-03-23 14:58:29,221 - luma_ge.sample_data - INFO - Unique classes in training data: [ 1  2  7  9 13 14 15]\n",
-      "2026-03-23 14:58:29,227 - luma_ge.sample_data - INFO - Class counts: {7: 42, 1: 26, 14: 11, 2: 10, 13: 4, 9: 3, 15: 3}\n",
-      "2026-03-23 14:58:29,228 - luma_ge.sample_data - INFO - Validating classes with use_class_ids=True\n",
-      "2026-03-23 14:58:29,230 - luma_ge.sample_data - INFO - Class field: kelas\n",
-      "2026-03-23 14:58:29,231 - luma_ge.sample_data - INFO - Training data type: <class 'geopandas.geodataframe.GeoDataFrame'>\n",
-      "2026-03-23 14:58:29,232 - luma_ge.sample_data - INFO - Landcover DF columns: ['ID', 'LULC_Type', 'Color Palette']\n",
-      "2026-03-23 14:58:29,233 - luma_ge.sample_data - INFO - Valid IDs in landcover_df: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]\n",
-      "2026-03-23 14:58:29,234 - luma_ge.sample_data - INFO - Processing GeoDataFrame with 99 features\n",
-      "2026-03-23 14:58:29,236 - luma_ge.sample_data - INFO - Unique classes in training data: [ 1  2  7  9 13 14 15]\n",
-      "2026-03-23 14:58:29,238 - luma_ge.sample_data - INFO - Valid class ID: 1\n",
-      "2026-03-23 14:58:29,240 - luma_ge.sample_data - INFO - Valid class ID: 2\n",
-      "2026-03-23 14:58:29,241 - luma_ge.sample_data - INFO - Valid class ID: 7\n",
-      "2026-03-23 14:58:29,243 - luma_ge.sample_data - INFO - Valid class ID: 9\n",
-      "2026-03-23 14:58:29,244 - luma_ge.sample_data - INFO - Valid class ID: 13\n",
-      "2026-03-23 14:58:29,245 - luma_ge.sample_data - INFO - Valid class ID: 14\n",
-      "2026-03-23 14:58:29,246 - luma_ge.sample_data - INFO - Valid class ID: 15\n",
-      "2026-03-23 14:58:29,247 - luma_ge.sample_data - INFO - Valid classes: [np.int64(1), np.int64(2), np.int64(7), np.int64(9), np.int64(13), np.int64(14), np.int64(15)]\n",
-      "2026-03-23 14:58:29,248 - luma_ge.sample_data - INFO - Invalid classes: []\n",
-      "2026-03-23 14:58:29,252 - luma_ge.sample_data - INFO - Features after class validation: 99\n"
+      "2026-03-24 09:48:19,577 - luma_ge.sample_data - INFO - Initial feature count: 1130000\n",
+      "2026-03-24 09:48:19,579 - luma_ge.sample_data - INFO - Filtering by AOI bounds...\n",
+      "2026-03-24 09:48:19,581 - luma_ge.sample_data - INFO - AOI geometry type: <class 'ee.geometry.Geometry'>\n",
+      "2026-03-24 09:48:22,305 - luma_ge.sample_data - INFO - Features after AOI filter: 99\n",
+      "2026-03-24 09:48:22,307 - luma_ge.sample_data - INFO - Converting to GeoDataFrame...\n",
+      "2026-03-24 09:48:23,809 - luma_ge.sample_data - INFO - Collection size: 99\n",
+      "2026-03-24 09:48:23,810 - luma_ge.sample_data - INFO - Collection size (99) is within normal limits, loading directly\n",
+      "2026-03-24 09:48:25,609 - luma_ge.sample_data - INFO - Features to convert: 99\n",
+      "2026-03-24 09:48:25,612 - luma_ge.sample_data - INFO - Successfully processed 99 features\n",
+      "2026-03-24 09:48:25,619 - luma_ge.sample_data - INFO - Unique classes in training data: [ 1  2  7  9 13 14 15]\n",
+      "2026-03-24 09:48:25,622 - luma_ge.sample_data - INFO - Class counts: {7: 42, 1: 26, 14: 11, 2: 10, 13: 4, 9: 3, 15: 3}\n",
+      "2026-03-24 09:48:25,623 - luma_ge.sample_data - INFO - Validating classes with use_class_ids=True\n",
+      "2026-03-24 09:48:25,624 - luma_ge.sample_data - INFO - Class field: kelas\n",
+      "2026-03-24 09:48:25,625 - luma_ge.sample_data - INFO - Training data type: <class 'geopandas.geodataframe.GeoDataFrame'>\n",
+      "2026-03-24 09:48:25,626 - luma_ge.sample_data - INFO - Landcover DF columns: ['ID', 'LULC_Type', 'Color Palette']\n",
+      "2026-03-24 09:48:25,629 - luma_ge.sample_data - INFO - Valid IDs in landcover_df: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]\n",
+      "2026-03-24 09:48:25,630 - luma_ge.sample_data - INFO - Processing GeoDataFrame with 99 features\n",
+      "2026-03-24 09:48:25,631 - luma_ge.sample_data - INFO - Unique classes in training data: [ 1  2  7  9 13 14 15]\n",
+      "2026-03-24 09:48:25,633 - luma_ge.sample_data - INFO - Valid class ID: 1\n",
+      "2026-03-24 09:48:25,635 - luma_ge.sample_data - INFO - Valid class ID: 2\n",
+      "2026-03-24 09:48:25,636 - luma_ge.sample_data - INFO - Valid class ID: 7\n",
+      "2026-03-24 09:48:25,637 - luma_ge.sample_data - INFO - Valid class ID: 9\n",
+      "2026-03-24 09:48:25,639 - luma_ge.sample_data - INFO - Valid class ID: 13\n",
+      "2026-03-24 09:48:25,640 - luma_ge.sample_data - INFO - Valid class ID: 14\n",
+      "2026-03-24 09:48:25,641 - luma_ge.sample_data - INFO - Valid class ID: 15\n",
+      "2026-03-24 09:48:25,642 - luma_ge.sample_data - INFO - Valid classes: [np.int64(1), np.int64(2), np.int64(7), np.int64(9), np.int64(13), np.int64(14), np.int64(15)]\n",
+      "2026-03-24 09:48:25,643 - luma_ge.sample_data - INFO - Invalid classes: []\n",
+      "2026-03-24 09:48:25,648 - luma_ge.sample_data - INFO - Features after class validation: 99\n"
      ]
     },
     {
@@ -2784,7 +2784,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-03-23 14:58:37,952 - pyogrio._io - INFO - Created 99 records\n"
+      "2026-03-24 09:48:35,846 - pyogrio._io - INFO - Created 99 records\n"
      ]
     },
     {
@@ -3187,7 +3187,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7fa23b3e0f3243bab4f83dc44cfa730e",
+       "model_id": "5d173b12d590431498a74242291f92af",
        "version_major": 2,
        "version_minor": 0
       },
@@ -3347,7 +3347,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7fa23b3e0f3243bab4f83dc44cfa730e",
+       "model_id": "5d173b12d590431498a74242291f92af",
        "version_major": 2,
        "version_minor": 0
       },
@@ -3469,7 +3469,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "073629f9721c4a05a11016e996eb7a21",
+       "model_id": "eb73bafd71b44f2e892c3c32e117c796",
        "version_major": 2,
        "version_minor": 0
       },
@@ -3576,14 +3576,22 @@
      },
      "metadata": {},
      "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ Thematic Accuracy Assessment class initialized\n",
+      "Supported metrics: ['overall_accuracy', 'kappa', 'producer_accuracy', 'user_accuracy', 'f1_scores', 'confusion_matrix']\n"
+     ]
     }
    ],
    "source": [
-    "# from luma_ge.accuracy import Thematic_Accuracy_Assessment\n",
-    "# #Initialize the accuracy assessment class\n",
-    "# accuracy_assessor = Thematic_Accuracy_Assessment()\n",
-    "# print(\"✓ Thematic Accuracy Assessment class initialized\")\n",
-    "# print(f\"Supported metrics: {accuracy_assessor.supported_metrics}\")"
+    "from luma_ge.accuracy import Thematic_Accuracy_Assessment\n",
+    "#Initialize the accuracy assessment class\n",
+    "accuracy_assessor = Thematic_Accuracy_Assessment()\n",
+    "print(\"✓ Thematic Accuracy Assessment class initialized\")\n",
+    "print(f\"Supported metrics: {accuracy_assessor.supported_metrics}\")"
    ]
   },
   {
@@ -3651,6 +3659,507 @@
     "#     print(\"Samples Used     :\", summary['sample_size'])\n",
     "# else:\n",
     "#     print(\"Error:\", results[\"error\"])\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ee858d19",
+   "metadata": {},
+   "source": [
+    "## Validate default map\n",
+    "\n",
+    "For Luma mock up version, after bypassing the classification scheme, the prebuilt map will not be validated. Therefore this part will not be used for mock up, but will be used for Luma protoype version with Epistem map"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 65,
+   "id": "8aafa6a4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ Classification image loaded\n",
+      "✓ Validation collection loaded: users/hadicu06/IIASA/RESTORE/accuracy_assessment_samples/stratified_samples_targ2percSEOverallAcc_localExpertsInterpreters\n",
+      "  → 1 validation features found\n"
+     ]
+    }
+   ],
+   "source": [
+    "validation_asset = \"users/hadicu06/IIASA/RESTORE/accuracy_assessment_samples/stratified_samples_targ2percSEOverallAcc_localExpertsInterpreters\"\n",
+    "validation_fc = ee.FeatureCollection(validation_asset).filterBounds(aoi)\n",
+    "default_map = final_map # R+ map\n",
+    "\n",
+    "# Quick sanity check — fetches only the count, not all features\n",
+    "n_features = validation_fc.size().getInfo()\n",
+    "print(f\"✓ Classification image loaded\")\n",
+    "print(f\"✓ Validation collection loaded: {validation_asset}\")\n",
+    "print(f\"  → {n_features} validation features found\")\n",
+    " \n",
+    "if n_features == 0:\n",
+    "    raise ValueError(\n",
+    "        \"Validation FeatureCollection is empty. \"\n",
+    "        \"Check the asset path and your EE permissions.\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 66,
+   "id": "51959dae",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "── Properties ───────────────────────────────\n",
+      "  Names  : ['class', 'confidence', 'consensus_type', 'consensus_type_meaning', 'eng_name', 'gee_class_id', 'location_id', 'name', 'point_id', 'sample_id']\n",
+      "  Sample : {'class': 11, 'confidence': None, 'consensus_type': None, 'consensus_type_meaning': None, 'eng_name': None, 'gee_class_id': None, 'location_id': None, 'name': None, 'point_id': None, 'sample_id': None}\n",
+      "  Coords : lon=103.1651, lat=-4.0231\n",
+      "{'type': 'Projection', 'crs': 'EPSG:4326', 'transform': [0.0009678465381381702, 0, 94.74733685103617, 0, -0.0009678465381381702, 6.3016488098176255]}\n",
+      "{'type': 'Projection', 'crs': 'EPSG:4326', 'transform': [1, 0, 0, 0, 1, 0]}\n",
+      "1\n"
+     ]
+    }
+   ],
+   "source": [
+    "first_feature   = validation_fc.first().getInfo()\n",
+    "prop_names      = list(first_feature[\"properties\"].keys())\n",
+    "sample_props    = first_feature[\"properties\"]\n",
+    "sample_geom     = first_feature[\"geometry\"][\"coordinates\"]   # [lon, lat]\n",
+    "\n",
+    "print(\"\\n── Properties ───────────────────────────────\")\n",
+    "print(f\"  Names  : {prop_names}\")\n",
+    "print(f\"  Sample : {sample_props}\")\n",
+    "print(f\"  Coords : lon={sample_geom[0]:.4f}, lat={sample_geom[1]:.4f}\")\n",
+    "\n",
+    "print(final_map.projection().getInfo())\n",
+    "print(validation_fc.first().geometry().projection().getInfo())\n",
+    "print(validation_fc.size().getInfo())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 57,
+   "id": "a0bc0de5",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "── Count per class (class) ────────────────\n",
+      "  Class ID       Count   Share\n",
+      "  ────────────────────────────\n",
+      "  1                105   23.1%\n",
+      "  2                 93   20.4%\n",
+      "  3                  5    1.1%\n",
+      "  4                  5    1.1%\n",
+      "  5                 14    3.1%\n",
+      "  6                 14    3.1%\n",
+      "  7                 43    9.5%\n",
+      "  8                 10    2.2%\n",
+      "  9                 20    4.4%\n",
+      "  10                34    7.5%\n",
+      "  11                14    3.1%\n",
+      "  12                 8    1.8%\n",
+      "  13                29    6.4%\n",
+      "  14                33    7.3%\n",
+      "  15                17    3.7%\n",
+      "  16                 7    1.5%\n",
+      "  17                 4    0.9%\n",
+      "  ────────────────────────────\n",
+      "  TOTAL            455\n"
+     ]
+    }
+   ],
+   "source": [
+    "class_property = 'class'   # e.g. \"CLASS_ID\"\n",
+    "\n",
+    "raw_counts = (\n",
+    "    validation_fc\n",
+    "    .reduceColumns(\n",
+    "        reducer    = ee.Reducer.frequencyHistogram(),\n",
+    "        selectors  = [class_property]\n",
+    "    )\n",
+    "    .get(\"histogram\")\n",
+    "    .getInfo()\n",
+    ")\n",
+    "\n",
+    "# Sort by class ID and print as a small table\n",
+    "print(f\"\\n── Count per class ({class_property}) ────────────────\")\n",
+    "print(f\"  {'Class ID':<12}{'Count':>8}{'Share':>8}\")\n",
+    "print(f\"  {'─'*28}\")\n",
+    "total = sum(raw_counts.values())\n",
+    "for cls_id, count in sorted(raw_counts.items(), key=lambda x: int(x[0])):\n",
+    "    share = count / total * 100\n",
+    "    print(f\"  {cls_id:<12}{count:>8}{share:>7.1f}%\")\n",
+    "print(f\"  {'─'*28}\")\n",
+    "print(f\"  {'TOTAL':<12}{total:>8}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 60,
+   "id": "52a711fe",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'classification': 0.9987310701815354}\n"
+     ]
+    }
+   ],
+   "source": [
+    "mask_check = final_map.mask().reduceRegion(\n",
+    "    reducer = ee.Reducer.mean(),\n",
+    "    geometry = aoi,\n",
+    "    scale = 30,\n",
+    "    maxPixels = 1e9\n",
+    ")\n",
+    "\n",
+    "print(mask_check.getInfo())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 58,
+   "id": "280096fd",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-03-24 10:15:50,184 - luma_ge.accuracy - INFO - Starting accuracy assessment...\n",
+      "2026-03-24 10:15:56,438 - luma_ge.accuracy - INFO - Accuracy assessment completed successfully\n"
+     ]
+    }
+   ],
+   "source": [
+    "success, results = accuracy_assessor.run_accuracy_assessment(\n",
+    "    lcmap           = default_map,\n",
+    "    validation_data = validation_fc,\n",
+    "    class_property  = 'class',\n",
+    "    scale           = 100,\n",
+    "    confidence      = 0.95,\n",
+    ")\n",
+    " \n",
+    "if not success:\n",
+    "    raise RuntimeError(f\"Assessment failed: {results.get('error', 'unknown error')}\")\n",
+    " "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9a381e2b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "THEMATIC ACCURACY ASSESSMENT — SUMMARY\n",
+      "Validation asset: users/hadicu06/IIASA/RESTORE/accuracy_assessment_samples/stratified_samples_targ2percSEOverallAcc_localExpertsInterpreters\n",
+      "Class property: class\n",
+      "Scale: 100 m\n",
+      "Confidence level: 95%\n",
+      "Total samples: 1\n",
+      "\n",
+      "OVERALL METRICS\n",
+      "Overall Accuracy (OA):   0.00%\n",
+      "95% Confidence Interval: 0.00% – 0.00%\n",
+      "Kappa Coefficient: 0.0000\n",
+      "\n",
+      "PER-CLASS METRICS\n",
+      "ID  Class Name                  Prod. Acc  User Acc  F1 Score  Samples\n",
+      "1   1                             0.00%      0.00%      0.00%        0\n",
+      "2   2                             0.00%      0.00%      0.00%        0\n",
+      "3   3                             0.00%      0.00%      0.00%        0\n",
+      "4   4                             0.00%      0.00%      0.00%        0\n",
+      "5   5                             0.00%      0.00%      0.00%        0\n",
+      "6   6                             0.00%      0.00%      0.00%        0\n",
+      "7   7                             0.00%      0.00%      0.00%        0\n",
+      "8   8                             0.00%      0.00%      0.00%        0\n",
+      "9   9                             0.00%      0.00%      0.00%        0\n",
+      "10  10                            0.00%      0.00%      0.00%        0\n",
+      "11  11                            0.00%      0.00%      0.00%        0\n",
+      "12  12                            0.00%      0.00%      0.00%        1\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "def write_report(results: dict) -> None: # alternative for format_accuracy_summary\n",
+    "    \"\"\"\n",
+    "    Print a simplified plain-text accuracy report.\n",
+    "    Derives everything from the results dict alone — no CONFIG dependency.\n",
+    "    \"\"\"\n",
+    "    # ── Derive display values from results dict ───────────────────────────────\n",
+    "    # class_ids and class_names are injected into results in Cell 5 below;\n",
+    "    # fall back to integer indices if they were never set.\n",
+    "    n_classes    = len(results[\"confusion_matrix\"])\n",
+    "    class_ids    = results.get(\"class_ids\",   list(range(n_classes)))\n",
+    "    class_names  = results.get(\"class_names\", [str(i) for i in class_ids])\n",
+    "\n",
+    "    cm           = results[\"confusion_matrix\"]\n",
+    "    oa           = results[\"overall_accuracy\"]\n",
+    "    ci_lo, ci_hi = results[\"overall_accuracy_ci\"]\n",
+    "    conf_pct     = int(results[\"confidence_level\"] * 100)\n",
+    "    row_sums     = [sum(cm[i]) for i in range(n_classes)]\n",
+    "\n",
+    "    lines = []\n",
+    "    a = lines.append\n",
+    "\n",
+    "    a(\"THEMATIC ACCURACY ASSESSMENT — SUMMARY\")\n",
+    "    a(f\"Validation asset: {validation_asset}\")\n",
+    "    a(f\"Class property: {class_property}\")\n",
+    "    a(f\"Scale: {results['scale']} m\")\n",
+    "    a(f\"Confidence level: {conf_pct}%\")\n",
+    "    a(f\"Total samples: {results['n_total']}\")\n",
+    "    a(\"\")\n",
+    "\n",
+    "    a(\"OVERALL METRICS\")\n",
+    "    a(f\"Overall Accuracy (OA): {oa * 100:6.2f}%\")\n",
+    "    a(f\"{conf_pct}% Confidence Interval: {ci_lo * 100:.2f}% – {ci_hi * 100:.2f}%\")\n",
+    "    a(f\"Kappa Coefficient: {results['kappa']:.4f}\")\n",
+    "    a(\"\")\n",
+    "\n",
+    "    a(\"PER-CLASS METRICS\")\n",
+    "    a(\"ID  Class Name                  Prod. Acc  User Acc  F1 Score  Samples\")\n",
+    "    for i in range(n_classes):\n",
+    "        a(\n",
+    "            f\"{class_ids[i]:<3} {class_names[i]:<25}\"\n",
+    "            f\"{results['producer_accuracy'][i] * 100:>9.2f}%  \"\n",
+    "            f\"{results['user_accuracy'][i]     * 100:>8.2f}%  \"\n",
+    "            f\"{results['f1_scores'][i]         * 100:>8.2f}%  \"\n",
+    "            f\"{row_sums[i]:>7}\"\n",
+    "        )\n",
+    "    a(\"\")\n",
+    "\n",
+    "    text = \"\\n\".join(lines)\n",
+    "    print(text)\n",
+    "\n",
+    "\n",
+    "# ── Attach class labels to results before writing ─────────────────────────────\n",
+    "# raw_counts was built in the inspection cell; keys are strings from EE\n",
+    "results[\"class_ids\"]   = sorted(int(k) for k in raw_counts.keys())\n",
+    "results[\"class_names\"] = [str(i) for i in results[\"class_ids\"]]  # replace with names if you have them\n",
+    "\n",
+    "# ── Print the simplified report ───────────────────────────────────────────────\n",
+    "write_report(results)\n"
    ]
   }
  ],

--- a/src/luma_ge/classification.py
+++ b/src/luma_ge/classification.py
@@ -113,8 +113,20 @@ class Generate_LULC:
         self._prebuilt_registry = {
             "RESTORE+ Project": {
                 "assets": {
-                    2018: "users/hadicu06/IIASA/RESTORE/classified_maps/class_hardened/with_crowdsourced_data/primary_classification" #PLACEHOLDER ASSET DIRECTORY
-                },
+                    2013: "projects/epistem-485512/assets/Indonesia_LULC_2013_100m",
+                    2014: "projects/epistem-485512/assets/Indonesia_LULC_2014_100m",
+                    2015: "projects/epistem-485512/assets/Indonesia_LULC_2015_100m",
+                    2016: "projects/epistem-485512/assets/Indonesia_LULC_2016_100m",
+                    2017: "projects/epistem-485512/assets/Indonesia_LULC_2017_100m",
+                    2018: "users/hadicu06/IIASA/RESTORE/classified_maps/class_hardened/with_crowdsourced_data/primary_classification", #PLACEHOLDER ASSET DIRECTORY
+                    2019: "projects/epistem-490415/assets/RESTORE/Indonesia_Mosaic_LULC_2019_100m",
+                    2020: "projects/epistem-490415/assets/RESTORE/Indonesia_Mosaic_LULC_2020_100m",
+                    2021: "projects/epistem-490415/assets/RESTORE/Indonesia_Mosaic_LULC_2021_100m",
+                    2022: "projects/epistem-490415/assets/RESTORE/Indonesia_Mosaic_LULC_2022_100m",
+                    2023: "projects/epistem-490415/assets/RESTORE/Indonesia_Mosaic_LULC_2023_100m",
+                    2024: "projects/epistem-485512/assets/Indonesia_LULC_2024_100m",
+                    2025: "users/Restore25/with_crowdsourced_data__primary_classification_2025"   
+                },  
                 "class_band": "classification",
                 "scale": 100,
             }
@@ -536,6 +548,7 @@ class Generate_LULC:
 
         # Load & clip 
         national_map = ee.Image(cfg["assets"][year_used])
+        print("[classify_from_prebuilt] Map resolution (m):", national_map.projection().nominalScale().getInfo())
         clipped_map  = national_map.clip(aoi)
 
         # Detect class IDs present in AOI

--- a/src/luma_ge/classification.py
+++ b/src/luma_ge/classification.py
@@ -108,6 +108,18 @@ class Generate_LULC:
         Perform classification to generate Land Cover Land Use Map. The parameters used in the classification should be the result of hyperparameter tuning
         """
 
+        # Registry of prebuilt wall-to-wall maps per default scheme.
+        # Add new years here as maps are finalized — nothing else needs to change.
+        self._prebuilt_registry = {
+            "RESTORE+ Project": {
+                "assets": {
+                    2018: "users/hadicu06/IIASA/RESTORE/classified_maps/class_hardened/with_crowdsourced_data/primary_classification" #PLACEHOLDER ASSET DIRECTORY
+                },
+                "class_band": "classification",
+                "scale": 100,
+            }
+        }
+
     ############################# 1. Multiclass Classification ###########################
     def hard_classification(self, training_data, class_property, image, ntrees = 100, 
                                   v_split = None, min_leaf = 1, return_model = False,  seed=0):
@@ -471,3 +483,100 @@ class Generate_LULC:
         }
 
         return final_map, metadata
+    
+    def classify_from_prebuilt(
+        self,
+        scheme_name: str,
+        aoi: ee.Geometry,
+        year: int,
+        scheme_classes: List[Dict[str, Any]],  # manager.classes passed in directly
+    ) -> Dict[str, Any]:
+        """
+        Bypass the full RF pipeline and return a clipped prebuilt wall-to-wall
+        map when the user selects a default scheme.
+
+        Replaces hard_classification() / soft_classification() when a prebuilt
+        map is available. The return dict mirrors what the RF path produces so
+        downstream code (display, export, legend) needs no branching.
+
+        Parameters
+        ----------
+        scheme_name    : str               — must match a key in _prebuilt_registry
+        aoi            : ee.Geometry       — user's area of interest
+        year           : int               — user's temporal input
+        scheme_classes : List[Dict]        — manager.classes (ID / Class Name / Color Code)
+
+        Returns
+        -------
+        Dict with keys:
+            final_map        : ee.Image        — clipped classified map
+            present_classes  : List[Dict]      — scheme_classes filtered to AOI
+            vis_params       : dict            — ee-style vis params
+            source           : str             — "prebuilt_bypass"
+            year_used        : int             — actual year loaded (may differ if fallback)
+            scheme           : str             — scheme_name
+        """
+        cfg = self._prebuilt_registry.get(scheme_name)
+        if cfg is None:
+            raise ValueError(
+                f"No prebuilt map registered for scheme '{scheme_name}'. "
+                f"Available: {list(self._prebuilt_registry.keys())}"
+            )
+
+        # Resolve year with graceful fallback 
+        available_years = sorted(cfg["assets"].keys())
+        year_used = year
+
+        if year not in cfg["assets"]:
+            year_used = min(available_years, key=lambda y: abs(y - year))
+            print(
+                f"[classify_from_prebuilt] Year {year} not available for '{scheme_name}'. "
+                f"Falling back to nearest: {year_used}. Available: {available_years}"
+            )
+
+        # Load & clip 
+        national_map = ee.Image(cfg["assets"][year_used])
+        clipped_map  = national_map.clip(aoi)
+
+        # Detect class IDs present in AOI
+        class_band = cfg["class_band"]
+        hist_dict = (
+            clipped_map
+            .select(class_band)
+            .reduceRegion(
+                reducer   = ee.Reducer.frequencyHistogram(),
+                geometry  = aoi,
+                scale     = cfg["scale"],
+                maxPixels = 1e13,
+            )
+            .get(class_band)
+            .getInfo()                          # {str(class_id): pixel_count}
+        )
+        present_ids = {int(k) for k, v in hist_dict.items() if v > 0}
+
+        # Filter legend to AOI-present classes 
+        # Reuses the exact names & colors already loaded in manager.classes,
+        # so Module 2 legend and final map legend are always consistent
+        present_classes = [c for c in scheme_classes if c['ID'] in present_ids]
+
+        # ── 5. Build vis params ───────────────────────────────────────────────
+        ids     = [c['ID']         for c in present_classes]
+        palette = [c['Color Code'] for c in present_classes]
+        labels  = [c['Class Name'] for c in present_classes]
+
+        vis_params = {
+            "bands":       [class_band],
+            "min":         min(ids) if ids else 0,
+            "max":         max(ids) if ids else 1,
+            "palette":     palette,
+            "class_names": labels,
+        }
+
+        return {
+            "final_map":       clipped_map,
+            "present_classes": present_classes,
+            "vis_params":      vis_params,
+            "source":          "prebuilt_bypass",
+            "year_used":       year_used,
+            "scheme":          scheme_name,
+        }


### PR DESCRIPTION
# Problem

This is the current luma-GE workflow (https://github.com/epistem-io/luma-stack/tree/v0.1.0) when a user chooses to use the default scheme:

1. Module 2: The system retains the default classes
2. Module 3: 
    1. The system load RESTORE+ training data from EE asset
    2. The system filters the training data based on user’s AOI
    3. The system conducts validation processes of the loaded AOI
    4. The system saved the variable as `TrainDataFinal`
3. Module 6: 
    1. The system creates an RF model based on `TrainDataFinal`

Some problems may arise within the current workflow:

1. If a training data is missing in the AOI, then the system cannot run the classification (https://github.com/epistem-io/LumaLite/issues/21)

# Solution

Use a premade wall-to-wall map of RESTORE+ data of different years (2013 to 2025 = 13 nation-wide RESTORE+ map) stored in GEE asset.

The code was intended as a temporary solution for deploying the Luma mock-up.

## Workflow summary

`classify_from_prebuilt` in `classification.py`:
- Checks if the prebuilt map is available based on the user's input year
- The system clips the map based on the AOI
- Checks the existing class inside the AOI for the legend

Implementation example is in `Module_implementation.ipynb` 

